### PR TITLE
EM-542: date range picker no filter

### DIFF
--- a/src/components/vanilla/controls/DateRangePicker/index.tsx
+++ b/src/components/vanilla/controls/DateRangePicker/index.tsx
@@ -53,6 +53,10 @@ export default (props: Props) => {
   }, [triggerBlur]);
 
   useEffect(() => {
+    if (!props.value.from && !props.value.to && !props.value.relativeTimeString) {
+      return setRange(props.value);
+    }
+
     if (!props.value?.relativeTimeString) return;
 
     const [from, to] = dateParser(props.value?.relativeTimeString, 'UTC');

--- a/src/components/vanilla/controls/Dropdown/index.tsx
+++ b/src/components/vanilla/controls/Dropdown/index.tsx
@@ -1,5 +1,13 @@
 import { DataResponse, useEmbeddableState } from '@embeddable.com/react';
-import React, { ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 
 import useFont from '../../../hooks/useFont';
 import Spinner from '../../Spinner';
@@ -29,6 +37,10 @@ export default (props: Props) => {
   const [_, setServerSearch] = useEmbeddableState({
     [props.searchProperty || 'search']: ''
   }) as any;
+
+  useEffect(() => {
+    setValue(props.defaultValue);
+  }, [props.defaultValue]);
 
   useFont();
 


### PR DESCRIPTION
# Description

When the user selects NoFilter, the component doesn't update to show that selection.
There is no update of the relative date picker.

Fix both.

# Evidence



https://github.com/embeddable-hq/vanilla-components/assets/57071299/22762f79-434b-42e3-ac33-05cffc7885de


