### PR TITLE
EM-000: HOTFIX wrong behaviour on the right side of the canvas

### DIFF
--- a/src/components/vanilla/controls/DateRangePicker/index.tsx
+++ b/src/components/vanilla/controls/DateRangePicker/index.tsx
@@ -114,8 +114,8 @@ export default (props: Props) => {
             onFocus={() => setFocus(true)}
             onBlur={() => setTriggerBlur(true)}
             className="absolute left-0 top-0 h-full w-full opacity-0 cursor-pointer"
-            // hotfix > weird layout when at the right side of canvas
-            style={{ width: '100%', height: '100%' }}
+            // Chrome issue: Interactive elements inherit props on shadowRoot on click
+            style={{ minWidth: 0 }}
           />
           <CalendarIcon className="mr-2 hidden sm:block" />
           {!props.hideDate && (

--- a/src/components/vanilla/controls/DateRangePicker/index.tsx
+++ b/src/components/vanilla/controls/DateRangePicker/index.tsx
@@ -3,6 +3,7 @@ import { endOfDay, getYear } from 'date-fns';
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { CaptionProps, DayPicker, useNavigation } from 'react-day-picker';
 import 'react-day-picker/dist/style.css';
+
 import formatValue from '../../../util/format';
 import Container from '../../Container';
 import { CalendarIcon, ChevronLeft, ChevronRight } from '../../icons';
@@ -113,6 +114,8 @@ export default (props: Props) => {
             onFocus={() => setFocus(true)}
             onBlur={() => setTriggerBlur(true)}
             className="absolute left-0 top-0 h-full w-full opacity-0 cursor-pointer"
+            // hotfix > weird layout when at the right side of canvas
+            style={{ width: '100%', height: '100%' }}
           />
           <CalendarIcon className="mr-2 hidden sm:block" />
           {!props.hideDate && (

--- a/src/components/vanilla/controls/Dropdown/index.tsx
+++ b/src/components/vanilla/controls/Dropdown/index.tsx
@@ -132,8 +132,8 @@ export default (props: Props) => {
           className={`outline-none bg-transparent leading-9 h-9 border-0 px-3 w-full cursor-pointer text-sm ${
             focus || !value ? '' : 'opacity-0'
           }`}
-          // hotfix > weird layout when at the right side of canvas
-          style={{ width: '100%', height: '100%' }}
+          // Chrome issue: Interactive elements inherit props on shadowRoot on click
+          style={{ minWidth: 0 }}
         />
 
         {!!value && (

--- a/src/components/vanilla/controls/Dropdown/index.tsx
+++ b/src/components/vanilla/controls/Dropdown/index.tsx
@@ -132,6 +132,8 @@ export default (props: Props) => {
           className={`outline-none bg-transparent leading-9 h-9 border-0 px-3 w-full cursor-pointer text-sm ${
             focus || !value ? '' : 'opacity-0'
           }`}
+          // hotfix > weird layout when at the right side of canvas
+          style={{ width: '100%', height: '100%' }}
         />
 
         {!!value && (

--- a/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
+++ b/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
@@ -146,6 +146,8 @@ export default (props: Props) => {
           className={`outline-none bg-transparent leading-9 h-9 border-0 px-3 w-full cursor-pointer text-sm ${
             focus || !value ? '' : 'opacity-0'
           }`}
+          // hotfix > weird layout when at the right side of canvas
+          style={{ width: '100%', height: '100%' }}
         />
 
         {!!value && (

--- a/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
+++ b/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
@@ -146,8 +146,8 @@ export default (props: Props) => {
           className={`outline-none bg-transparent leading-9 h-9 border-0 px-3 w-full cursor-pointer text-sm ${
             focus || !value ? '' : 'opacity-0'
           }`}
-          // hotfix > weird layout when at the right side of canvas
-          style={{ width: '100%', height: '100%' }}
+          // Chrome issue: Interactive elements inherit props on shadowRoot on click
+          style={{ minWidth: 0 }}
         />
 
         {!!value && (

--- a/src/components/vanilla/controls/NumberInput/index.tsx
+++ b/src/components/vanilla/controls/NumberInput/index.tsx
@@ -27,8 +27,8 @@ export default (props: Props) => {
           type="number"
           placeholder={props.placeholder}
           className="rounded-xl w-full h-full outline-none leading-10 border-0 px-3"
-          // hotfix > weird layout when at the right side of canvas
-          style={{ width: '100%', height: '100%' }}
+          // Chrome issue: Interactive elements inherit props on shadowRoot on click
+          style={{ minWidth: 0 }}
           onChange={(e) => {
             setValue(e.target.value);
             if (timeout) {

--- a/src/components/vanilla/controls/NumberInput/index.tsx
+++ b/src/components/vanilla/controls/NumberInput/index.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-
-
 import Container from '../../Container';
 import { ClearIcon } from '../../icons';
-
 
 type Props = {
   onChange: (v: string) => void;
@@ -30,6 +27,8 @@ export default (props: Props) => {
           type="number"
           placeholder={props.placeholder}
           className="rounded-xl w-full h-full outline-none leading-10 border-0 px-3"
+          // hotfix > weird layout when at the right side of canvas
+          style={{ width: '100%', height: '100%' }}
           onChange={(e) => {
             setValue(e.target.value);
             if (timeout) {

--- a/src/components/vanilla/controls/TextInput/index.tsx
+++ b/src/components/vanilla/controls/TextInput/index.tsx
@@ -37,8 +37,8 @@ export default (props: Props) => {
           ref={ref}
           placeholder={props.placeholder}
           className="rounded-xl w-full outline-none leading-10 h-full border-0 px-3"
-          // hotfix > weird layout when at the right side of canvas
-          style={{ width: '100%', height: '100%' }}
+          // Chrome issue: Interactive elements inherit props on shadowRoot on click
+          style={{ minWidth: 0 }}
           onChange={handleChange}
           defaultValue={value}
         />

--- a/src/components/vanilla/controls/TextInput/index.tsx
+++ b/src/components/vanilla/controls/TextInput/index.tsx
@@ -28,7 +28,7 @@ export default (props: Props) => {
     timeout = window.setTimeout(() => {
       props.onChange(e.target.value);
     }, 1000);
-  }
+  };
 
   return (
     <Container title={props.title}>
@@ -37,6 +37,8 @@ export default (props: Props) => {
           ref={ref}
           placeholder={props.placeholder}
           className="rounded-xl w-full outline-none leading-10 h-full border-0 px-3"
+          // hotfix > weird layout when at the right side of canvas
+          style={{ width: '100%', height: '100%' }}
           onChange={handleChange}
           defaultValue={value}
         />


### PR DESCRIPTION
THIS IS A HOTFIX

The component that use an <input> element , are inheriting styles that are messing with the layout of the component and its behavior.

This fix makes the input occupy the available space so it doesnt move arround.

This will require a deeper investigation.


Before (check the video of harry):

https://trevorio.atlassian.net/jira/software/c/projects/EM/boards/10?selectedIssue=EM-804

https://github.com/embeddable-hq/vanilla-components/assets/57071299/1024d0ad-a131-48bd-a075-4443abd68361


After:

https://github.com/embeddable-hq/vanilla-components/assets/57071299/b0a5c665-75fc-4be7-8dfa-ce17d380dda3


