### PR TITLE
Minor filter value change

### DIFF
--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -134,16 +134,12 @@ export default defineComponent(Component, meta, {
         ],
         measures: inputs.metrics,
         filters:
-          inputs.timeFilter?.to && inputs.xAxis
+          inputs.timeFilter && inputs.xAxis
             ? [
                 {
                   property: inputs.xAxis,
                   operator: 'inDateRange',
-                  value: {
-                    from: inputs.timeFilter.from,
-                    to: inputs.timeFilter.to,
-                    relativeTimeString: ''
-                  }
+                  value: inputs.timeFilter
                 }
               ]
             : undefined

--- a/src/components/vanilla/charts/KPIChart/KPIChart.emb.ts
+++ b/src/components/vanilla/charts/KPIChart/KPIChart.emb.ts
@@ -97,7 +97,7 @@ export default defineComponent(Component, meta, {
         from: inputs.ds,
         measures: [inputs.metric],
         filters:
-          inputs.timeFilter?.from && inputs.timeProperty
+          inputs.timeFilter && inputs.timeProperty
             ? [
                 {
                   property: inputs.timeProperty,


### PR DESCRIPTION
Inputs.timeFilter?.from condition removed, leaving only inputs.timeFilter in comparison charts, as per Misha suggestion (so that a filter is always passed in)