### PR TITLE
Stacked Area Chart breaking when nulls are present in the dataset.

### DIFF
--- a/src/components/vanilla/charts/StackedAreaChart/StackedAreaChart.emb.ts
+++ b/src/components/vanilla/charts/StackedAreaChart/StackedAreaChart.emb.ts
@@ -118,7 +118,12 @@ export default defineComponent(Component, meta, {
           }
         ],
         dimensions: [inputs.segment],
-        measures: [inputs.metric]
+        measures: [inputs.metric],
+        filters: [{
+          property: inputs.xAxis,
+          operator: 'notEquals',
+          value: [null]
+        }]
       })
     };
   }


### PR DESCRIPTION
Nulls filtered out