### PR TITLE
Update minimal node version to 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Hello and welcome to our Embeddable components **starter pack** built just for y
 
 ### Installation
 
-`npm i` # requires node 18 or later
+`npm i` # requires node 20 or later
 
 ### Build & Deploy
 This is how you push code changes to your Embeddable workspace


### PR DESCRIPTION
Updates Node version mentioned in documentation to 20.

The code change was done in scope of https://github.com/embeddable-hq/vanilla-components/commit/a05084b484f8f1664bcb0bb291a0e39eb6dba024