### PR TITLE
Bug fix in datepicker

### DIFF
--- a/src/components/vanilla/controls/DatePicker/components/DateRangePicker.tsx
+++ b/src/components/vanilla/controls/DatePicker/components/DateRangePicker.tsx
@@ -19,6 +19,7 @@ const ranges = [
   'Last month',
   'This quarter',
   'Last quarter',
+  'Last 6 months',
   'This year',
   'Last year'
 ];
@@ -138,7 +139,8 @@ export default function DateRangePicker(props: Props) {
           >
             <DayPicker
               showOutsideDays
-              className="border border-[#d8dad9] bg-white rounded-xl shadow px-4 py-3 text-[#101010] !m-0"
+              required={true}
+              className="border border-[#d8dad9] bg-white rounded-xl px-4 py-3 text-[#101010] !m-0"
               components={{
                 Caption: CustomCaption
               }}
@@ -146,6 +148,7 @@ export default function DateRangePicker(props: Props) {
               mode="range"
               selected={{ from: range?.from, to: range?.to }}
               onSelect={(range) => {
+
                 setRange({ ...range, relativeTimeString: 'Custom' });
 
                 if (!range?.from || !range?.to) return;
@@ -172,7 +175,7 @@ const CustomCaption = (props: CaptionProps) => {
   return (
     <h2 className="flex items-center">
       <button
-        className="w-7 h-7 bg-white rounded shadow border border-slate-500 justify-center items-center inline-flex"
+        className="w-7 h-7 bg-white rounded border border-slate-400 justify-center items-center inline-flex"
         disabled={!previousMonth}
         onClick={() => previousMonth && goToMonth(previousMonth)}
       >
@@ -182,7 +185,7 @@ const CustomCaption = (props: CaptionProps) => {
         {formatValue(props.displayMonth.toJSON(), { dateFormat: 'MMMM yyy' })}
       </span>
       <button
-        className="w-7 h-7 bg-white rounded shadow border border-slate-500 justify-center items-center inline-flex"
+        className="w-7 h-7 bg-white rounded border border-slate-400 justify-center items-center inline-flex"
         disabled={!nextMonth}
         onClick={() => nextMonth && goToMonth(nextMonth)}
       >

--- a/src/components/vanilla/controls/DatePicker/components/DateRangeWithGranularity.tsx
+++ b/src/components/vanilla/controls/DatePicker/components/DateRangeWithGranularity.tsx
@@ -24,7 +24,6 @@ export type Props = {
 
 export default function DateRangeWithGranularity(props: Props) {
   const { onChangeComparison, onChangePeriod, defaultPeriod } = props;
-
   const ref = useRef<HTMLDivElement | null>(null);
   const [hideDate, setHideDate] = useState(false);
   const [period, setPeriod] = useState(defaultPeriod);
@@ -85,7 +84,6 @@ export default function DateRangeWithGranularity(props: Props) {
       onChangePeriod(defaultPeriod as TimeRange);
       return;
     }
-    setPeriod(defaultPeriod);
   }, [defaultPeriod, onChangePeriod]);
 
 

--- a/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
+++ b/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
@@ -72,15 +72,20 @@ export function getComparisonPeriod(rts, period) {
 }
 
 export function getNote(from: Date, to: Date) {
-	return `${format(
-	from,
-	getYear(from) === getYear(new Date()) ? 'd MMM' : 'd MMM yyyy'
-	)} - ${format(to, getYear(to) === getYear(new Date()) ? 'd MMM' : 'd MMM yyyy')}`;
+
+  const formattedFrom = format(from, getYear(from) === getYear(new Date()) ? 'd MMM' : 'd MMM yyyy');
+
+  const formattedTo = format(to, getYear(to) === getYear(new Date()) ? 'd MMM' : 'd MMM yyyy');
+
+  if (formattedFrom === formattedTo) {
+    return formattedFrom;
+  } else {
+    return `${formattedFrom} - ${formattedTo}`;
+  }	
 }
 
 export function getValidGranularities(period?: TimeRange): DataResponse {
   const data: { value: Granularity }[] = [];
-
   
   //period boundaries for valid granularity options
   const gSettings = {


### PR DESCRIPTION
**Description**
Fix bug whereby the period in the date range picker was diverging from Embeddable state (causing the date dropdown to have to be clicked twice)
- Minor styling changes, including only showing a single date in the comparison picker for single days
- Additional period added to relative time string options in dropdown ('6 months')