### PR TITLE
Line chart sort issue

### DIFF
--- a/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
@@ -105,6 +105,13 @@ export const meta = {
       category: 'Formatting'
     },
     {
+        name: 'limit',
+        type: 'number',
+        label: 'Limit results',
+        defaultValue: 100,
+        category: 'Chart settings'
+    },
+    {
       name: 'enableDownloadAsCSV',
       type: 'boolean',
       label: 'Show download as CSV',
@@ -116,12 +123,15 @@ export const meta = {
 
 export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
+
     return {
       ...inputs,
+      isTSBarChart: true,
       reverseXAxis: true,
       useCustomDateFormat: true,
       results: loadData({
         from: inputs.ds,
+        limit: inputs.limit || 500,
         timeDimensions: [
           {
             dimension: inputs.xAxis?.name,

--- a/src/components/vanilla/charts/BarChart/index.tsx
+++ b/src/components/vanilla/charts/BarChart/index.tsx
@@ -1,5 +1,6 @@
 import Container from '../../Container';
 import BarChart from './components/BarChart';
+import useTimeseries from '../../../hooks/useTimeseries';
 import { DataResponse, Dataset, Dimension, Granularity, Measure } from '@embeddable.com/core';
 
 
@@ -21,9 +22,20 @@ type Props = {
   yAxisTitle?: string;
   metrics: Measure[];
   granularity?: Granularity;
+  limit?: number;
 };
 
 export default (props: Props) => {
+
+  //add missing dates to time-series barcharts
+  const { fillGaps } = useTimeseries(props, 'desc');
+  const { results, isTSBarChart } = props;
+  const updatedProps = {
+    ...props,
+    results: isTSBarChart
+      ? { ...props.results, data: results?.data?.reduce(fillGaps, []) }
+      : props.results
+  };
 
   return (
     <Container
@@ -31,7 +43,7 @@ export default (props: Props) => {
       className="overflow-y-hidden"
       >
       <BarChart
-        {...props}
+        {...updatedProps}
       />
     </Container>
   );

--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -129,11 +129,20 @@ export const meta = {
 
 export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
+
+    const orderProp = [];
+
+    orderProp.push({
+        property: inputs.xAxis,
+        direction: 'desc',
+    })
+
     return {
       ...inputs,
       results: loadData({
         from: inputs.ds,
         limit: 500,
+        orderBy: orderProp,
         timeDimensions: [
           {
             dimension: inputs.xAxis?.name,
@@ -161,6 +170,7 @@ export default defineComponent(Component, meta, {
           }
         ],
         limit: !inputs.prevTimeFilter ? 1 : 500,
+        orderBy: orderProp,
         measures: inputs.metrics,
         filters:
           inputs.prevTimeFilter && inputs.xAxis

--- a/src/components/vanilla/charts/CompareLineChart/index.tsx
+++ b/src/components/vanilla/charts/CompareLineChart/index.tsx
@@ -85,7 +85,7 @@ export default (propsInitial: Props) => {
     [propsInitial]
   );
 
-  const { fillGaps } = useTimeseries(props);
+  const { fillGaps } = useTimeseries(props, 'desc');
 
   const chartData: ChartData<'line'> = useMemo(() => {
     const { results, prevResults, metrics, applyFill } = props;

--- a/src/components/vanilla/charts/LineChart/LineChart.emb.ts
+++ b/src/components/vanilla/charts/LineChart/LineChart.emb.ts
@@ -98,6 +98,13 @@ export const meta = {
         defaultValue: true
     },
     {
+        name: 'limit',
+        type: 'number',
+        label: 'Limit results',
+        defaultValue: 100,
+        category: 'Chart settings'
+    },
+    {
         name: 'dps',
         type: 'number',
         label: 'Decimal Places',
@@ -115,10 +122,20 @@ export const meta = {
 
 export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
+
+    const orderProp = [];
+
+    orderProp.push({
+        property: inputs.xAxis,
+        direction: 'desc',
+    })
+
     return {
       ...inputs,
       results: loadData({
         from: inputs.ds,
+        limit: inputs.limit || 500,
+        orderBy: orderProp,
         timeDimensions: [
           {
             dimension: inputs.xAxis?.name,

--- a/src/components/vanilla/charts/LineChart/index.tsx
+++ b/src/components/vanilla/charts/LineChart/index.tsx
@@ -61,7 +61,7 @@ type Record = { [p: string]: string };
 
 export default (props: Props) => {
   const { results, title } = props;
-  const { fillGaps } = useTimeseries(props);
+  const { fillGaps } = useTimeseries(props, 'desc');
 
   const chartData: ChartData<'line'> = useMemo(() => {
     const { results, metrics, applyFill } = props;

--- a/src/components/vanilla/charts/LineChart/index.tsx
+++ b/src/components/vanilla/charts/LineChart/index.tsx
@@ -44,17 +44,18 @@ ChartJS.defaults.plugins.tooltip.enabled = true;
 
 type Props = {
   results: DataResponse;
-  title: string;
+  title?: string;
   dps?: number;
   xAxis: Dimension;
   metrics: { name: string; title: string }[];
-  applyFill: boolean;
-  showLabels: boolean;
-  showLegend: boolean;
-  yAxisMin: number;
-  yAxisTitle: string;
-  xAxisTitle: string;
-  granularity: Granularity;
+  applyFill?: boolean;
+  showLabels?: boolean;
+  showLegend?: boolean;
+  yAxisMin?: number;
+  yAxisTitle?: string;
+  xAxisTitle?: string;
+  granularity?: Granularity;
+  limit?: number;
 };
 
 type Record = { [p: string]: string };

--- a/src/components/vanilla/charts/StackedAreaChart/MultiDimensionLineChart.emb.ts
+++ b/src/components/vanilla/charts/StackedAreaChart/MultiDimensionLineChart.emb.ts
@@ -92,6 +92,13 @@ export const meta = {
         category: 'Chart settings'
     },
     {
+        name: 'limit',
+        type: 'number',
+        label: 'Limit results',
+        defaultValue: 100,
+        category: 'Chart settings'
+    },
+    {
         name: 'dps',
         type: 'number',
         label: 'Decimal Places',
@@ -109,11 +116,21 @@ export const meta = {
 
 export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
+
+    const orderProp = [];
+
+    orderProp.push({
+        property: inputs.xAxis,
+        direction: 'desc',
+    })
+
     return {
       ...inputs,
       isMultiDimensionLine: true,
       results: loadData({
         from: inputs.ds,
+        limit: inputs.limit || 500,
+        orderBy: orderProp,
         timeDimensions: [
           {
             dimension: inputs.xAxis?.name,

--- a/src/components/vanilla/charts/StackedAreaChart/StackedAreaChart.emb.ts
+++ b/src/components/vanilla/charts/StackedAreaChart/StackedAreaChart.emb.ts
@@ -105,6 +105,13 @@ export const meta = {
         category: 'Formatting'
     },
     {
+        name: 'limit',
+        type: 'number',
+        label: 'Limit results',
+        defaultValue: 100,
+        category: 'Chart settings'
+    },
+    {
         name: 'enableDownloadAsCSV',
         type: 'boolean',
         label: 'Show download as CSV',
@@ -116,10 +123,20 @@ export const meta = {
 
 export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
+
+    const orderProp = [];
+
+    orderProp.push({
+        property: inputs.xAxis,
+        direction: 'desc',
+    })
+
     return {
       ...inputs,
       results: loadData({
         from: inputs.ds,
+        limit: inputs.limit || 500,
+        orderBy: orderProp,
         timeDimensions: [
           {
             dimension: inputs.xAxis?.name,

--- a/src/components/vanilla/charts/StackedAreaChart/index.tsx
+++ b/src/components/vanilla/charts/StackedAreaChart/index.tsx
@@ -50,7 +50,7 @@ export default (props: Props) => {
 
   const { isMultiDimensionLine = false } = props;
 
-  const { fillGaps } = useTimeseries(props);
+  const { fillGaps } = useTimeseries(props, 'desc');
 
   const chartData = useMemo(() => {
     const data = props?.results?.data?.reduce(fillGaps, []);

--- a/src/components/vanilla/charts/StackedBarChart/TimeSeriesStackedBarChart.emb.ts
+++ b/src/components/vanilla/charts/StackedBarChart/TimeSeriesStackedBarChart.emb.ts
@@ -119,6 +119,7 @@ export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
     return {
       ...inputs,
+      isTSStackedBarChart: true,
       reverseXAxis: true,
       useCustomDateFormat: true,
       results: loadData({

--- a/src/components/vanilla/charts/StackedBarChart/index.tsx
+++ b/src/components/vanilla/charts/StackedBarChart/index.tsx
@@ -17,6 +17,7 @@ import { Bar } from 'react-chartjs-2';
 import { EMB_FONT, LIGHT_FONT, SMALL_FONT_SIZE } from '../../../constants';
 import getBarChartOptions from '../../../util/getBarChartOptions';
 import getStackedChartData, { Props } from '../../../util/getStackedChartData';
+import useTimeseries from '../../../hooks/useTimeseries';
 import Container from '../../Container';
 
 ChartJS.register(
@@ -37,14 +38,22 @@ ChartJS.defaults.font.family = EMB_FONT;
 ChartJS.defaults.plugins.tooltip.enabled = true;
 
 export default (props: Props) => {
-  const { results, title } = props;
-
   const datasetsMeta = {
     barPercentage: 0.6,
     barThickness: 'flex',
     maxBarThickness: 25,
     minBarLength: 0,
     borderRadius: 3
+  };
+
+  //add missing dates to time-series stacked barcharts
+  const { fillGaps } = useTimeseries(props, 'desc');
+  const { results, isTSStackedBarChart } = props;
+  const updatedProps = {
+    ...props,
+    results: isTSStackedBarChart
+      ? { ...props.results, data: results?.data?.reduce(fillGaps, []) }
+      : props.results
   };
 
   return (
@@ -54,7 +63,7 @@ export default (props: Props) => {
       <Bar
         height="100%"
         options={getBarChartOptions({ ...props, stacked: true })}
-        data={getStackedChartData(props, datasetsMeta) as ChartData<'bar', number[], unknown>}
+        data={getStackedChartData(updatedProps, datasetsMeta) as ChartData<'bar', number[], unknown>}
       />
     </Container>
   );


### PR DESCRIPTION
fillgaps function updated so that it fills missing dates whether data is sorted in asc or desc order. 
Related time-series charts updated with limit and orderby props. 