### PR TITLE
TPS-358 - Pivot Table Time Zone

### DIFF
--- a/src/components/util/format.ts
+++ b/src/components/util/format.ts
@@ -1,4 +1,6 @@
-import { format as formatDate, parseJSON } from 'date-fns';
+import { format as formatDate } from 'date-fns';
+
+import { parseTime } from '../hooks/useTimezone';
 
 type Type = 'number' | 'date' | 'string';
 
@@ -14,7 +16,7 @@ function numberFormatter(dps: number | undefined | null) {
   const fallback = dps == null || dps < 0;
   return new Intl.NumberFormat(undefined, {
     minimumFractionDigits: fallback ? 0 : dps, // Minimum number of digits after the decimal
-    maximumFractionDigits: fallback ? 2 : dps // Maximum number of digits after the decimal
+    maximumFractionDigits: fallback ? 2 : dps, // Maximum number of digits after the decimal
   });
 }
 
@@ -40,7 +42,7 @@ export default function formatValue(str: string = '', opt: Type | Options = 'str
       : wrap(str);
   }
 
-  if (dateFormat && str) return wrap(formatDate(parseJSON(str), dateFormat));
+  if (dateFormat && str) return wrap(formatDate(parseTime(str), dateFormat));
 
   return str;
 


### PR DESCRIPTION
Resolves an issue where PivotTable dates were displaying differently depending on the user's timezone (eg: not showing 10/29 for users in Pacific Time despite data coming in from 10/29 UTC).

Fixes TPS-358

**Acceptance Criteria**

It's a little complicated to replicate this - you need to create a pivot table that contains dates, set your granularity to day, then manually change your computer over to a different timezone that's behind UTC, and then test against data that exists for the current UTC date. I've done this and can confirm that the code change works. I correctly see data for 10/29 (the date of this PR) even when set to San Francisco time.

Here's a screenshot of it working - before the fix the last date in the table was 10/28. With the fix, even in Pacific time, the last date in the table is correctly showing as 10/29:

<img width="1839" alt="Screenshot 2024-10-29 at 02 56 01" src="https://github.com/user-attachments/assets/0a020ea9-db0b-4ed8-a8c8-e70bba98c538">

