### PR TITLE
Line display option added to bar charts

### DIFF
--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -13,13 +13,17 @@ export default function getBarChartOptions({
   yAxisTitle = '',
   xAxisTitle = '',
   dps = undefined,
-  reverseXAxis = false
+  reverseXAxis = false,
+  showSecondYAxis = false,
+  secondAxisTitle = ''
 }: Partial<Props> & {
   stacked?: boolean;
   stackMetrics?: boolean;
   yAxisTitle?: string;
   xAxisTitle?: string;
   reverseXAxis?: boolean;
+  showSecondYAxis?: boolean;
+  secondAxisTitle?: string;
 }): ChartOptions<'bar' | 'line'> {
   return {
     responsive: true,
@@ -59,6 +63,18 @@ export default function getBarChartOptions({
           display: !!yAxisTitle,
           text: yAxisTitle
         }
+      },
+      y1: {//optional second y-axis for optional line metrics
+        display: showSecondYAxis,
+        grace: '0%',
+        grid: {
+          display: false
+        },
+        position: 'right',
+        title: {
+          display: !!secondAxisTitle,
+          text: secondAxisTitle
+        },        
       },
       x: {
         reverse: reverseXAxis && !displayHorizontally,

--- a/src/components/vanilla/charts/BarChart/BarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/BarChart.emb.ts
@@ -52,6 +52,30 @@ export const meta = {
       category: 'Chart data',
     },
     {
+      name: 'lineMetrics',
+      type: 'measure',
+      array: true,
+      label: 'Add a line(s)',
+      config: {
+        dataset: 'ds',
+      },
+      category: 'Optional chart data',
+    },
+    {
+      name: 'showSecondYAxis',
+      type: 'boolean',
+      label: 'Show 2nd axis',
+      category: 'Optional chart data',
+      defaultValue: false,
+    },  
+    {
+      name: 'secondAxisTitle',
+      type: 'string',
+      label: '2nd axis title',
+      description: 'The title for the chart',
+      category: 'Optional chart data',
+    },  
+    {
       name: 'title',
       type: 'string',
       label: 'Title',
@@ -157,7 +181,7 @@ export default defineComponent(Component, meta, {
       results: loadData({
         from: inputs.ds,
         dimensions: [inputs.xAxis],
-        measures: inputs.metrics,
+        measures: [...inputs.metrics, ...(inputs.lineMetrics || [])],
         orderBy: orderProp,
         limit: inputs.limit || 50,
       }),

--- a/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
@@ -38,6 +38,30 @@ export const meta = {
       category: 'Chart data',
     },
     {
+      name: 'lineMetrics',
+      type: 'measure',
+      array: true,
+      label: 'Add a line(s)',
+      config: {
+        dataset: 'ds',
+      },
+      category: 'Optional chart data',
+    },
+    {
+      name: 'showSecondYAxis',
+      type: 'boolean',
+      label: 'Show 2nd axis',
+      category: 'Optional chart data',
+      defaultValue: false,
+    },  
+    {
+      name: 'secondAxisTitle',
+      type: 'string',
+      label: '2nd axis title',
+      description: 'The title for the chart',
+      category: 'Optional chart data',
+    }, 
+    {
       name: 'granularity',
       type: 'granularity',
       label: 'Granularity',
@@ -144,7 +168,7 @@ export default defineComponent(Component, meta, {
             granularity: inputs.granularity,
           },
         ],
-        measures: inputs.metrics,
+        measures: [...inputs.metrics, ...(inputs.lineMetrics || [])],
         filters: [
           {
             property: inputs.xAxis,

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -6,14 +6,15 @@ import {
   Chart as ChartJS,
   Filler,
   Legend,
-  LinearScale,
   PointElement,
+  LineElement,
+  LinearScale,
   Title,
   Tooltip,
 } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import React from 'react';
-import { Bar } from 'react-chartjs-2';
+import { Chart } from 'react-chartjs-2';
 
 import {
   COLORS,
@@ -30,6 +31,7 @@ ChartJS.register(
   LinearScale,
   PointElement,
   BarElement,
+  LineElement,
   Title,
   Tooltip,
   Legend,
@@ -48,6 +50,7 @@ type Props = {
   dps?: number;
   enableDownloadAsCSV?: boolean;
   metrics: Measure[];
+  lineMetrics?: Measure[];
   results?: DataResponse;
   reverseXAxis?: boolean;
   showLabels?: boolean;
@@ -59,11 +62,14 @@ type Props = {
   xAxisTitle?: string;
   yAxisTitle?: string;
   granularity?: Granularity;
+  showSecondYAxis?: boolean;
+  secondAxisTitle?: string;
 };
 
 export default function BarChart({ ...props }: Props) {
   return (
-    <Bar
+    <Chart
+      type="bar"
       height="100%"
       options={getBarChartOptions({ ...props, stacked: false })}
       data={chartData(props)}
@@ -71,8 +77,8 @@ export default function BarChart({ ...props }: Props) {
   );
 }
 
-function chartData(props: Props): ChartData<'bar'> {
-  const { results, xAxis, metrics, granularity } = props;
+function chartData(props: Props): ChartData<'bar' | 'line'> {
+  const { results, xAxis, metrics, granularity, lineMetrics, showSecondYAxis } = props;
 
   let dateFormat: string | undefined;
   if (xAxis.nativeType === 'time' && granularity) {
@@ -91,18 +97,34 @@ function chartData(props: Props): ChartData<'bar'> {
     ),
   ] as string[];
 
+  const metricsDatasets =  metrics?.map((metric, i) => ({
+    barPercentage: 0.8,
+    barThickness: 'flex',
+    maxBarThickness: 50,
+    minBarLength: 0,
+    borderRadius: 4,
+    label: metric.title,
+    data: results?.data?.map((d) => parseFloat(d[metric.name])) || [],
+    backgroundColor: COLORS[i % COLORS.length],
+    order: 1
+  })) || [];
+
+  //optional metrics to display as a line on the barchart 
+  const lineMetricsDatasets = lineMetrics?.map((metric, i) => ({
+      label: metric.title,
+      data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
+      backgroundColor: COLORS[metrics.length + i % COLORS.length],
+      borderColor: COLORS[metrics.length + i % COLORS.length],
+      cubicInterpolationMode: 'monotone' as const,
+      pointRadius: 2,
+      pointHoverRadius: 3,
+      type: 'line' as const,
+      order: 0,
+      yAxisID: showSecondYAxis ? 'y1' : 'y',
+  })) || [];
+
   return {
     labels,
-    datasets:
-      metrics?.map((metric, i) => ({
-        barPercentage: 0.8,
-        barThickness: 'flex',
-        maxBarThickness: 50,
-        minBarLength: 0,
-        borderRadius: 4,
-        label: metric.title,
-        data: results?.data?.map((d) => parseFloat(d[metric.name])) || [],
-        backgroundColor: COLORS[i % COLORS.length],
-      })) || [],
+    datasets: [...metricsDatasets, ...lineMetricsDatasets]
   };
 }

--- a/src/components/vanilla/charts/BarChart/index.tsx
+++ b/src/components/vanilla/charts/BarChart/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   isTSBarChart?: boolean;
   limit?: number;
   metrics: Measure[];
+  lineMetrics?: Measure[];
   results: DataResponse;
   reverseXAxis?: boolean;
   showLabels?: boolean;
@@ -23,6 +24,8 @@ type Props = {
   xAxis: Dimension;
   xAxisTitle?: string;
   yAxisTitle?: string;
+  showSecondYAxis?: boolean;
+  secondAxisTitle?: string;
 };
 
 export default (props: Props) => {


### PR DESCRIPTION
Line metric option added to bar chart and time-series bar chart. 
The user can select multiple metrics, and also choose whether to show these on a separate right-side axis. The user can optionally also add a title to this right-axis. 