### PR TITLE
Format function for measures now receives pretext and posttext meta

### DIFF
--- a/src/components/util/format.ts
+++ b/src/components/util/format.ts
@@ -8,7 +8,7 @@ type Options = {
   type?: Type;
   truncate?: number;
   dateFormat?: string;
-  meta?: { prefix?: string; suffix?: string };
+  meta?: { pretext?: string; posttext?: string };
   dps?: number;
 };
 
@@ -38,7 +38,7 @@ export default function formatValue(str: string = '', opt: Type | Options = 'str
 
   if (truncate) {
     return str?.length > truncate
-      ? `${meta?.prefix || ''}${str.substring(0, truncate)}...`
+      ? `${meta?.pretext || ''}${str.substring(0, truncate)}...`
       : wrap(str);
   }
 
@@ -47,6 +47,6 @@ export default function formatValue(str: string = '', opt: Type | Options = 'str
   return str;
 
   function wrap(v: string) {
-    return `${meta?.prefix || ''}${v}${meta?.suffix || ''}`;
+    return `${meta?.pretext || ''}${v}${meta?.posttext || ''}`;
   }
 }

--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -118,7 +118,7 @@ export default function getBarChartOptions({
               label += `: ${formatValue(`${context.parsed[axis]}`, { 
                 type: 'number', 
                 dps: dps, 
-                meta: metricObj?.meta 
+                meta: displayAsPercentage ? undefined : metricObj?.meta 
               })}`;
               if (displayAsPercentage) {
                 label += '%';
@@ -142,7 +142,7 @@ export default function getBarChartOptions({
           let val = formatValue(v, { 
             type: 'number', 
             dps: dps,
-            meta: metricObj?.meta 
+            meta: displayAsPercentage ? undefined : metricObj?.meta 
           });
           if (displayAsPercentage) {
             val += '%';

--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -1,5 +1,5 @@
 import { ChartOptions } from 'chart.js';
-
+import { Measure } from '@embeddable.com/core';
 import formatValue from '../util/format';
 import { Props } from './getStackedChartData';
 
@@ -13,13 +13,17 @@ export default function getBarChartOptions({
   yAxisTitle = '',
   xAxisTitle = '',
   dps = undefined,
-  reverseXAxis = false
+  reverseXAxis = false,
+  metrics,
+  metric
 }: Partial<Props> & {
   stacked?: boolean;
   stackMetrics?: boolean;
   yAxisTitle?: string;
   xAxisTitle?: string;
   reverseXAxis?: boolean;
+  metrics?: Measure[];
+  metric?: Measure;
 }): ChartOptions<'bar' | 'line'> {
   return {
     responsive: true,
@@ -105,9 +109,17 @@ export default function getBarChartOptions({
         callbacks: {
           label: function (context) {
             let label = context.dataset.label || '';
+            //metric needed for formatting
+            const metricIndex = context.datasetIndex;
+            //a single metric is sometimes passed in (e.g. for stacked bar charts)
+            const metricObj = metrics ? metrics[metricIndex] : metric;
             if (context.parsed && typeof context.parsed === 'object') {
               const axis = displayHorizontally ? 'x' : 'y';
-              label += `: ${formatValue(`${context.parsed[axis]}`, { type: 'number', dps: dps })}`;
+              label += `: ${formatValue(`${context.parsed[axis]}`, { 
+                type: 'number', 
+                dps: dps, 
+                meta: metricObj?.meta 
+              })}`;
               if (displayAsPercentage) {
                 label += '%';
               }
@@ -121,9 +133,17 @@ export default function getBarChartOptions({
         anchor: stacked || stackMetrics ? 'center' : 'end',
         align: stacked || stackMetrics ? 'center' : 'end',
         display: showLabels ? 'auto' : false,
-        formatter: (v) => {
+        formatter: (v, context) => {
+          //metric needed for formatting
+          const metricIndex = context.datasetIndex;
+          //a single metric is sometimes passed in (e.g. for stacked bar charts)
+          const metricObj = metrics ? metrics[metricIndex] : metric;
           if (v === null) return null;
-          let val = formatValue(v, { type: 'number', dps: dps });
+          let val = formatValue(v, { 
+            type: 'number', 
+            dps: dps,
+            meta: metricObj?.meta 
+          });
           if (displayAsPercentage) {
             val += '%';
           }

--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -29,7 +29,7 @@ export default function getBarChartOptions({
   metric?: Measure;
   showSecondYAxis?: boolean;
   secondAxisTitle?: string;
-  lineMetrics: Measure[];
+  lineMetrics?: Measure[];
 }): ChartOptions<'bar' | 'line'> {
   return {
     responsive: true,

--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -15,6 +15,7 @@ export default function getBarChartOptions({
   dps = undefined,
   reverseXAxis = false,
   metrics,
+  lineMetrics,
   metric,
   showSecondYAxis = false,
   secondAxisTitle = ''
@@ -28,7 +29,7 @@ export default function getBarChartOptions({
   metric?: Measure;
   showSecondYAxis?: boolean;
   secondAxisTitle?: string;
-
+  lineMetrics: Measure[];
 }): ChartOptions<'bar' | 'line'> {
   return {
     responsive: true,
@@ -129,7 +130,8 @@ export default function getBarChartOptions({
             //metric needed for formatting
             const metricIndex = context.datasetIndex;
             //a single metric is sometimes passed in (e.g. for stacked bar charts)
-            const metricObj = metrics ? metrics[metricIndex] : metric;
+            const metricsList = [...(metrics || []), ...(lineMetrics||[])];
+            const metricObj = metrics ? metricsList[metricIndex] : metric;
             if (context.parsed && typeof context.parsed === 'object') {
               const axis = displayHorizontally ? 'x' : 'y';
               label += `: ${formatValue(`${context.parsed[axis]}`, { 
@@ -154,7 +156,8 @@ export default function getBarChartOptions({
           //metric needed for formatting
           const metricIndex = context.datasetIndex;
           //a single metric is sometimes passed in (e.g. for stacked bar charts)
-          const metricObj = metrics ? metrics[metricIndex] : metric;
+          const metricsList = [...(metrics || []), ...(lineMetrics||[])];
+          const metricObj = metrics ? metricsList[metricIndex] : metric;
           if (v === null) return null;
           let val = formatValue(v, { 
             type: 'number', 

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -104,7 +104,7 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
     minBarLength: 0,
     borderRadius: 4,
     label: metric.title,
-    data: results?.data?.map((d) => parseFloat(d[metric.name])) || [],
+    data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
     backgroundColor: COLORS[i % COLORS.length],
     order: 1
   })) || [];

--- a/src/components/vanilla/charts/BubbleChart/index.tsx
+++ b/src/components/vanilla/charts/BubbleChart/index.tsx
@@ -166,7 +166,11 @@ function chartOptions(props: Props, updatedData: Record[] | undefined, bubbleDat
         },
         formatter: (_, {dataIndex}) => {
           const v = updatedData?.[dataIndex][props.bubbleSize.name] || 0;
-          const val = formatValue(v, { type: 'number', dps: props.dps || 0 }) || null;
+          const val = formatValue(v, { 
+            type: 'number', 
+            dps: props.dps || 0, 
+            meta: props.bubbleSize.meta 
+          }) || null;
           return val;
         }
       },
@@ -179,14 +183,16 @@ function chartOptions(props: Props, updatedData: Record[] | undefined, bubbleDat
             const rawData = context.raw as { y: number };
             const yAxisValue = formatValue((`${rawData.y || ''}`), {
                 type: 'number',
-                dps: props.dps
+                dps: props.dps,
+                meta: props.yAxis.meta
               });
             //Bubble size label
             const bubbleSizeLabel = props.bubbleSize.title;
             const bubbleSizeValue = updatedData?.[context.dataIndex][props.bubbleSize.name] || 0;
             const bubbleSizeValueFormatted = formatValue((bubbleSizeValue), {
                 type: 'number',
-                dps: props.dps
+                dps: props.dps,
+                meta: props.bubbleSize.meta
               });            
             return [`${yAxisLabel}: ${yAxisValue}`, `${bubbleSizeLabel}: ${bubbleSizeValueFormatted}`];
           }

--- a/src/components/vanilla/charts/KPIChart/index.tsx
+++ b/src/components/vanilla/charts/KPIChart/index.tsx
@@ -83,7 +83,12 @@ export default (props: Props) => {
                   color: `${LIGHTEST_FONT}`,
                 }}
               >
-                {`${metric.title}: ${formatValue(`${results?.data?.[0]?.[metric.name]}`, { type: 'number', dps: dps })}`}
+                {`${metric.title}: ${formatValue(`${results?.data?.[0]?.[metric.name]}`, { 
+                    type: 'number', 
+                    dps: dps,
+                    meta: metric?.meta 
+                  })}
+                `}
               </p>
             )}
           </>

--- a/src/components/vanilla/charts/LineChart/LineChart.emb.ts
+++ b/src/components/vanilla/charts/LineChart/LineChart.emb.ts
@@ -141,6 +141,12 @@ export default defineComponent(Component, meta, {
       results: loadData({
         from: inputs.ds,
         limit: inputs.limit || 500,
+        filters: [
+          {
+            property: inputs.xAxis,
+            operator: 'notNull',
+          },
+        ],
         orderBy: orderProp,
         timeDimensions: [
           {

--- a/src/components/vanilla/charts/PieChart/index.tsx
+++ b/src/components/vanilla/charts/PieChart/index.tsx
@@ -1,4 +1,4 @@
-import { DataResponse } from '@embeddable.com/core';
+import { DataResponse, Measure, Dimension } from '@embeddable.com/core';
 import {
   ArcElement,
   CategoryScale,
@@ -42,8 +42,8 @@ type Props = {
   results: DataResponse;
   title: string;
   dps?: number;
-  slice: { name: string; meta?: object };
-  metric: { name: string; title: string };
+  slice: Dimension
+  metric: Measure;
   showLabels?: boolean;
   showLegend?: boolean;
   maxSegments?: number;
@@ -124,7 +124,11 @@ function chartOptions(props: Props): ChartOptions<'pie'> {
           weight: 'normal',
         },
         formatter: (v) => {
-          const val = v ? formatValue(v, { type: 'number', dps: props.dps }) : null;
+          const val = v ? formatValue(v, { 
+            type: 'number', 
+            dps: props.dps,
+            meta: props.displayAsPercentage ? undefined : props.metric.meta
+           }) : null;
           return props.displayAsPercentage ? `${val}%` : val;
         },
       },
@@ -137,6 +141,7 @@ function chartOptions(props: Props): ChartOptions<'pie'> {
               label += `: ${formatValue(`${context.parsed || ''}`, {
                 type: 'number',
                 dps: props.dps,
+                meta: props.displayAsPercentage ? undefined : props.metric.meta
               })}`;
             }
             label = props.displayAsPercentage ? `${label}%` : label;

--- a/src/components/vanilla/charts/PivotTable/PivotTable.tsx
+++ b/src/components/vanilla/charts/PivotTable/PivotTable.tsx
@@ -98,6 +98,11 @@ const PivotTable = <T,>({
     return sortRows(rows, sortCriteriaWithDataAccessor);
   }, [rows, sortCriteriaWithDataAccessor]);
 
+
+  const getMeasureByLabel = useMemo(() => (label: string) => {
+    return measures.find(measure => measure.title === label);
+  }, [measures]);
+
   return (
     <table className="min-w-full border-separate border-spacing-0 table-fixed">
       <thead className="text-[#333942] sticky top-0 z-20 bg-white">
@@ -134,9 +139,12 @@ const PivotTable = <T,>({
                     cellValue === undefined || cellValue === null
                       ? nullValueCharacter
                       : formatValue(cellValue, {
+                        //format date columns
                         ...(granularity && column.dataType === 'time' ? {
                           dateFormat: DATE_DISPLAY_FORMATS[granularity as keyof typeof DATE_DISPLAY_FORMATS]
-                        } : {})
+                        } : {}),
+                        //format measures
+                        ...(getMeasureByLabel(column.label) ? { meta: getMeasureByLabel(column.label)?.meta, type: 'number' } : {})
                       })
                   }
                 </span>

--- a/src/components/vanilla/charts/ScatterChart/index.tsx
+++ b/src/components/vanilla/charts/ScatterChart/index.tsx
@@ -150,8 +150,14 @@ function chartOptions(props: Props, scatterData: ChartData<'scatter'>): ChartOpt
                 font: {
                 weight: 'normal'
                 },
-                formatter: (v) => {
-                    const val = v ? formatValue(v.y, { type: 'number', dps: props.dps }) : null;
+                formatter: (v, context) => {
+                    const metricIndex = context.datasetIndex;
+                    const metric = props.metrics[metricIndex];
+                    const val = v ? formatValue(v.y, { 
+                        type: 'number', 
+                        dps: props.dps,
+                        meta: metric?.meta
+                    }) : null;
                     return val;
                 },
             },
@@ -160,10 +166,13 @@ function chartOptions(props: Props, scatterData: ChartData<'scatter'>): ChartOpt
                 callbacks: {
                     label: function (context) {
                     let label = context.dataset.label || '';
+                    const metricIndex = context.datasetIndex;
+                    const metric = props.metrics[metricIndex];
                     if (context.parsed.y !== null) {
                         label += `: ${formatValue(`${context.parsed['y']}`, {
-                        type: 'number',
-                        dps: props.dps,
+                            type: 'number',
+                            dps: props.dps,
+                            meta: metric?.meta
                         })}`;
                     }
                     return label;

--- a/src/components/vanilla/charts/StackedAreaChart/index.tsx
+++ b/src/components/vanilla/charts/StackedAreaChart/index.tsx
@@ -96,6 +96,7 @@ export default (props: Props) => {
         y: {
           stacked: !isMultiDimensionLine,
           min: props.yAxisMin,
+          max: props.displayAsPercentage ? 100 : undefined,
           grace: '0%', // Add percent to add numbers on the y-axis above and below the max and min values
           grid: {
             display: false
@@ -147,7 +148,8 @@ export default (props: Props) => {
               if (context.parsed.y !== null) {
                 label += `: ${formatValue(`${context.parsed['y']}`, {
                   type: 'number',
-                  dps: props.dps
+                  dps: props.dps,
+                  meta: props.displayAsPercentage ? undefined : props.metric.meta
                 })}`;
                 if (props.displayAsPercentage) {
                   label += '%';
@@ -162,7 +164,11 @@ export default (props: Props) => {
           align: 'top',
           display: props.showLabels ? 'auto' : false,
           formatter: (v) => {
-            let val = v ? formatValue(v, { type: 'number', dps: props.dps }) : null;
+            let val = v ? formatValue(v, { 
+              type: 'number', 
+              dps: props.dps,
+              meta: props.displayAsPercentage ? undefined : props.metric.meta
+            }) : null;
             if (props.displayAsPercentage) {
               val += '%';
             }

--- a/src/models/cubes/products.cube.yml
+++ b/src/models/cubes/products.cube.yml
@@ -27,6 +27,9 @@ cubes:
         type: sum
         title: Total USD
         sql: price_usd
+        meta: 
+          pretext: '$'
+          posttext: ''
 
     joins:
       - name: orders # the name of the data model to join to (not the table)


### PR DESCRIPTION
You can now add pre and post-text meta to your models, like so:

```
- name: price
        type: sum
        title: Total USD
        sql: price_usd
        meta: 
          pretext: '$'
          posttext: ''
```
and it will automatically add these within the vanilla repo code via the format function, where those measures are displayed.

<img width="678" alt="Screenshot 2024-11-08 at 10 16 46" src="https://github.com/user-attachments/assets/49c4b4e0-d9c9-4a4e-8960-f069f346851c">
 
I've updated quite a few files. I've played with this and it works, but please test this. 

