### PR TITLE
Enable the user to select a clickable table cell e.g. to filter other widgets

### DIFF
--- a/src/components/vanilla/charts/TableChart/TableChart.emb.ts
+++ b/src/components/vanilla/charts/TableChart/TableChart.emb.ts
@@ -5,11 +5,13 @@ import {
   isDimension,
   isMeasure,
   loadData,
+  Value
 } from '@embeddable.com/core';
 import { EmbeddedComponentMeta, Inputs, defineComponent } from '@embeddable.com/react';
 
 import SortDirectionType from '../../../../types/SortDirection.type.emb';
 import Component, { Props } from './index';
+import { Column } from '../PivotTable/core/Column';
 
 export const meta = {
   name: 'TableChart',
@@ -101,6 +103,28 @@ export const meta = {
       label: 'Font size in pixels',
       category: 'Chart styling',
     },
+    {
+      name: 'interactiveColumn',
+      type: 'dimension',
+      label: 'Select a clickable column',
+      config: {
+        dataset: 'ds',
+        supportedTypes: ['string'],
+      },
+      category: 'Interactivity',
+    },
+  ],
+  events: [
+    {
+      name: 'onClick',
+      label: 'Click Interactive Column',
+      properties: [
+        {
+          name: 'value',
+          type: 'string',
+        },
+      ],
+    },
   ],
 } as const satisfies EmbeddedComponentMeta;
 
@@ -147,5 +171,12 @@ export default defineComponent<
         orderBy: state?.sort || defaultSort,
       }),
     };
+  },
+  events: {
+    onClick: (value) => {
+      return {
+        value: value || Value.noFilter(),
+      };
+    },
   },
 });

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -1,4 +1,4 @@
-import { DataResponse, DimensionOrMeasure, OrderBy, OrderDirection } from '@embeddable.com/core';
+import { DataResponse, DimensionOrMeasure, OrderBy, OrderDirection, Dimension } from '@embeddable.com/core';
 import { useEmbeddableState } from '@embeddable.com/react';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -17,6 +17,8 @@ export type Props = {
   title: string;
   fontSize?: number;
   minColumnWidth?: number;
+  interactiveColumn?: Dimension;
+  onClick: (v?:string) => void;
 };
 
 type Meta = { page: number; maxRowsFit: number; sort: OrderBy[] };
@@ -76,6 +78,14 @@ export default (props: Props) => {
     [meta, setMeta],
   );
 
+  const handleClick = (value:string, isInteractive:boolean) => {
+    if(value && isInteractive){
+      props.onClick(value);
+    } else {
+      props.onClick();
+    }
+  }
+
   return (
     <Container
       {...props}
@@ -105,20 +115,26 @@ export default (props: Props) => {
             <tbody>
               {results?.data?.slice(0, maxRowsFit).map((row, index) => (
                 <tr key={index} className="hover:bg-gray-400/5">
-                  {columns.map((column, index) => (
+                  {columns.map((column, index) => {
+
+                    const isInteractive = props.interactiveColumn?.name === column.name;
+                    const cellValue = row[column.name];
+
+                    return (
                     <td
                       key={index}
-                      className="text-dark p-3 truncate"
+                      onClick={() => handleClick(cellValue, isInteractive)}
+                      className={`text-dark p-3 truncate ${isInteractive ? 'cursor-pointer underline decoration-dotted' : ''}`}
                       style={{
                         fontSize: props.fontSize ? `${props.fontSize}px` : REGULAR_FONT_SIZE,
                         maxWidth: props.minColumnWidth ? `${props.minColumnWidth * 1.2}px` : 'auto',
                       }}
                     >
-                      <span title={formatColumn(row[column.name], column) ?? ''}>
-                        {formatColumn(row[column.name], column)}
+                      <span title={formatColumn(cellValue, column) ?? ''}>
+                        {formatColumn(cellValue, column)}
                       </span>
                     </td>
-                  ))}
+                  )})}
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
- Users can select an 'interactive' column via the inputs. 
- If this column exists in the results, it will enable it to be clicked (assuming the user has manually configured an interaction and connected it to a variable).
- If the user clicks in any other column, Value.noFilter() is applied. 
- If the column doesn't exist, nothing happens. 

https://github.com/user-attachments/assets/d2b9c96c-5e53-4c56-ba94-1af5fca61c60

