### PR TITLE
add sorting and reverse x axis to stacked bar chart

### DIFF
--- a/src/components/vanilla/charts/StackedBarChart/StackedBarChart.emb.ts
+++ b/src/components/vanilla/charts/StackedBarChart/StackedBarChart.emb.ts
@@ -1,4 +1,4 @@
-import { loadData } from '@embeddable.com/core';
+import { OrderBy, loadData } from '@embeddable.com/core';
 import { EmbeddedComponentMeta, Inputs, defineComponent } from '@embeddable.com/react';
 
 import Component from './index';
@@ -37,6 +37,15 @@ export const meta = {
       name: 'metric',
       type: 'measure',
       label: 'Metric',
+      config: {
+        dataset: 'ds',
+      },
+      category: 'Chart data',
+    },
+    {
+      name: 'sortBy',
+      type: 'dimensionOrMeasure',
+      label: 'Sort by (optional)',
       config: {
         dataset: 'ds',
       },
@@ -85,6 +94,13 @@ export const meta = {
       category: 'Chart settings',
     },
     {
+      name: 'reverseXAxis',
+      type: 'boolean',
+      label: 'Reverse X Axis',
+      category: 'Chart settings',
+      defaultValue: false,
+    },
+    {
       name: 'displayAsPercentage',
       type: 'boolean',
       label: 'Display as Percentages',
@@ -116,12 +132,22 @@ export const meta = {
 
 export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
+    const orderProp: OrderBy[] = [];
+
+    if (inputs.sortBy) {
+      orderProp.push({
+        property: inputs.sortBy,
+        direction: inputs.sortBy.nativeType == 'string' ? 'asc' : 'desc',
+      });
+    }
+
     return {
       ...inputs,
       results: loadData({
         from: inputs.ds,
         dimensions: [inputs.xAxis, inputs.segment],
         measures: [inputs.metric],
+        orderBy: orderProp,
       }),
     };
   },


### PR DESCRIPTION
Fulfills the request mentioned here: https://charts-roadmap.embeddable.com/roadmap/add-sorting-on-the-x-axis-to-the-stacked-bar-chart

"In the bar chart component you can specify how to sort the position of the bars in the X axis, it would be great to have this ability in the stacked bar chart as well."

**Acceptance Criteria**

 - Code should look good
 - Stacked Bar Chart should order by the user's choice (see screenshot)
 - Stacked Bar Chart should be able to be reversed (see second screenshot)

Sorted by Product Name:
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/d55dc34f-dd7f-478e-98b9-36a925d4a397">

Reversed:
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/8a08ce31-2db8-4336-bba5-c395ef2ee4a4">
