### PR TITLE
Download Button - Wait for Click to Load Data

### DIFF
--- a/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
+++ b/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
@@ -61,7 +61,6 @@ export const meta = {
 export default defineComponent<Props, typeof meta, { downloading: boolean }>(Component, meta, {
   props: (inputs: Inputs<typeof meta>, [state]) => {
     const downloading = state?.downloading === false;
-    console.log(state);
     let results = {
       isLoading: false,
     };

--- a/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
+++ b/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
@@ -1,5 +1,5 @@
+import { Dimension, Measure, isDimension, isMeasure, loadData } from '@embeddable.com/core';
 import { EmbeddedComponentMeta, Inputs, defineComponent } from '@embeddable.com/react';
-import { loadData, isMeasure, isDimension, Dimension, Measure } from '@embeddable.com/core';
 
 import Component, { Props } from './index';
 
@@ -11,63 +11,74 @@ export const meta = {
   category: 'Download options',
   inputs: [
     {
-        name: 'ds',
-        type: 'dataset',
-        label: 'Dataset to download from',
-        category: 'Data'
+      name: 'ds',
+      type: 'dataset',
+      label: 'Dataset to download from',
+      category: 'Data',
     },
     {
-        name: 'columns',
-        type: 'dimensionOrMeasure',
-        array: true,
-        label: 'Columns to include in download',
-        config: {
-            dataset: 'ds'
-        },
-        category: 'Data'
+      name: 'columns',
+      type: 'dimensionOrMeasure',
+      array: true,
+      label: 'Columns to include in download',
+      config: {
+        dataset: 'ds',
+      },
+      category: 'Data',
     },
     {
-        name: 'title',
-        type: 'string',
-        label: 'Title',
-        description: 'The title for the button',
-        category: 'Settings'
+      name: 'title',
+      type: 'string',
+      label: 'Title',
+      description: 'The title for the button',
+      category: 'Settings',
     },
     {
-        name: 'description',
-        type: 'string',
-        label: 'Description',
-        description: 'The description for the button',
-        category: 'Settings'
+      name: 'description',
+      type: 'string',
+      label: 'Description',
+      description: 'The description for the button',
+      category: 'Settings',
     },
     {
-        name: 'buttonLabel',
-        type: 'string',
-        label: 'Button label',
-        description: 'The text to show on the button',
-        defaultValue: 'Download',
-        category: 'Settings'
+      name: 'buttonLabel',
+      type: 'string',
+      label: 'Button label',
+      description: 'The text to show on the button',
+      defaultValue: 'Download',
+      category: 'Settings',
     },
     {
-        name: 'maxRows',
-        type: 'number',
-        label: 'Maximum number of rows to download',
-        defaultValue: 100,
-        category: 'Settings'
-    }
-  ]
+      name: 'maxRows',
+      type: 'number',
+      label: 'Maximum number of rows to download',
+      defaultValue: 100,
+      category: 'Settings',
+    },
+  ],
 } as const satisfies EmbeddedComponentMeta;
 
-export default defineComponent<Props, typeof meta, { page: number }>(Component, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
-    return {
-      ...inputs,
-      results: loadData({
+export default defineComponent<Props, typeof meta, { downloading: boolean }>(Component, meta, {
+  props: (inputs: Inputs<typeof meta>, [state]) => {
+    const downloading = state?.downloading === false;
+    console.log(state);
+    let results = {
+      isLoading: false,
+    };
+    if (downloading) {
+      results = loadData({
         from: inputs.ds,
         dimensions: inputs.columns.filter((c) => isDimension(c)).map((c) => c as Dimension),
         measures: inputs.columns.filter((c) => isMeasure(c)).map((c) => c as Measure),
-        limit: inputs.maxRows || undefined
-      })
+        limit: inputs.maxRows || undefined,
+      });
+      return {
+        ...inputs,
+        results,
+      };
+    }
+    return {
+      ...inputs,
     };
-  }
+  },
 });

--- a/src/components/vanilla/charts/DownloadButton/index.tsx
+++ b/src/components/vanilla/charts/DownloadButton/index.tsx
@@ -1,4 +1,5 @@
 import { DataResponse, DimensionOrMeasure } from '@embeddable.com/core';
+import { useEmbeddableState } from '@embeddable.com/react';
 import React, { useState } from 'react';
 
 import downloadAsCSV from '../../../util/downloadAsCSV';
@@ -13,13 +14,19 @@ type DataResponseData = { [key: string]: any };
 
 export type Props = {
   columns: DimensionOrMeasure[];
-  results: DataResponseWithPrevData;
+  results?: DataResponseWithPrevData;
   buttonLabel: string;
 };
 
 export default (props: Props) => {
   const { results, buttonLabel } = props;
 
+  const [embeddableState, setEmbeddableState] = useEmbeddableState<{
+    downloading: boolean;
+  }>({ downloading: false }) as unknown as [
+    { downloading: boolean },
+    React.Dispatch<React.SetStateAction<{ downloading: boolean }>>,
+  ];
   const [preppingDownload, setPreppingDownload] = useState(false);
 
   const downloadSVG = (
@@ -47,15 +54,16 @@ export default (props: Props) => {
         buttonLabel={buttonLabel}
         showSpinner={preppingDownload}
         disabled={results?.isLoading || preppingDownload}
-        onClick={() =>
+        onClick={() => {
+          setEmbeddableState({ downloading: true });
           downloadAsCSV(
             props,
             results?.data,
             results?.prevData,
             'downloaded-chart-data',
             setPreppingDownload,
-          )
-        }
+          );
+        }}
         icon={downloadSVG}
       />
     </Container>


### PR DESCRIPTION
**Description**
Previously, the download button snagged data when the Embeddable loaded. This meant with large datasets it would spin and spin, whether or not the user ever intended on downloading the data. We've changed the behavior using embeddable state so that the results are only loaded on click

Note: we're continuing to also use a local state variable for the spinner because I didn't want to rewrite the download CSV function to handle the nested state from `useEmbeddableState` and overcomplicate this PR, but I'm open to pushback on that.

**Acceptance Criteria**
- [x] No data should be loaded when button renders
- [x] Button should enter into a spinner mode when clicked
- [x] Button should load data as expected
- [x] Button should create a CSV file as expected
- [x] Button should leave spinner mode after CSV download isinitiated