### PR TITLE
Format axes

### DIFF
--- a/src/components/util/chartjs/common.ts
+++ b/src/components/util/chartjs/common.ts
@@ -15,6 +15,6 @@ export function setYAxisStepSize(
     const yAxisContainsFractions = containsFractions(results, metrics);  
     if (axis.options && 'ticks' in axis.options) {
       (axis.options.ticks as any).stepSize = 
-        ((!yAxisContainsFractions && yAxisMax <= 10) || dps === 0) ? 1 : undefined;
+        ((!yAxisContainsFractions && yAxisMax <= 10) || (dps === 0 && yAxisMax <= 10)) ? 1 : undefined;
     }
   }

--- a/src/components/util/chartjs/common.ts
+++ b/src/components/util/chartjs/common.ts
@@ -1,0 +1,20 @@
+import { DataResponse, Measure } from '@embeddable.com/core';
+import { Scale, CoreScaleOptions } from 'chart.js';
+import { containsFractions } from '../dataUtils'
+
+
+export function setYAxisStepSize(
+  axis: Scale<CoreScaleOptions>, 
+  results:DataResponse | undefined, 
+  metrics:Measure[],
+  dps:number|undefined
+) {
+    // Capture the max value for dynamic stepSize calculation
+    const yAxisMax = axis.max;
+    //Disable fractions unless they exist in the data.
+    const yAxisContainsFractions = containsFractions(results, metrics);  
+    if (axis.options && 'ticks' in axis.options) {
+      (axis.options.ticks as any).stepSize = 
+        ((!yAxisContainsFractions && yAxisMax <= 10) || dps === 0) ? 1 : undefined;
+    }
+  }

--- a/src/components/util/chartjs/common.ts
+++ b/src/components/util/chartjs/common.ts
@@ -15,6 +15,6 @@ export function setYAxisStepSize(
     const yAxisContainsFractions = containsFractions(results, metrics);  
     if (axis.options && 'ticks' in axis.options) {
       (axis.options.ticks as any).stepSize = 
-        ((!yAxisContainsFractions && yAxisMax <= 10) || (dps === 0 && yAxisMax <= 10)) ? 1 : undefined;
+        (yAxisMax <= 10 && (!yAxisContainsFractions || dps === 0)) ? 1 : undefined;
     }
   }

--- a/src/components/util/dataUtils.ts
+++ b/src/components/util/dataUtils.ts
@@ -1,0 +1,9 @@
+import { DataResponse, Measure } from '@embeddable.com/core';
+
+type Metrics = Measure[] | undefined;
+
+export function containsFractions(results:DataResponse | undefined, metrics: Metrics) {
+    return results?.data?.some(row =>
+        metrics?.find(metric => !Number.isInteger(row[metric.name]))
+    ) ?? false; // Return false if data or metricsGroup is undefined
+  }

--- a/src/components/util/getStackedChartData.ts
+++ b/src/components/util/getStackedChartData.ts
@@ -80,9 +80,9 @@ export default function getStackedChartData(
     const met = d[metric?.name || ''];
 
     if (segments.includes(seg)) {
-      resultMap[axis][seg] = parseInt(met);
+      resultMap[axis][seg] = parseFloat(met);
     } else {
-      resultMap[axis]['Other'] = (resultMap[axis]['Other'] || 0) + parseInt(met);
+      resultMap[axis]['Other'] = (resultMap[axis]['Other'] || 0) + parseFloat(met);
     }
   });
 

--- a/src/components/vanilla/charts/BubbleChart/index.tsx
+++ b/src/components/vanilla/charts/BubbleChart/index.tsx
@@ -22,6 +22,7 @@ import { Bubble } from 'react-chartjs-2';
 import { COLORS, EMB_FONT, LIGHT_FONT, SMALL_FONT_SIZE, DATE_DISPLAY_FORMATS } from '../../../constants';
 import formatValue from '../../../util/format';
 import hexToRgb from '../../../util/hexToRgb';
+import { setYAxisStepSize } from '../../../util/chartjs/common';
 
 ChartJS.register(
   CategoryScale,
@@ -100,8 +101,6 @@ function chartOptions(props: Props, updatedData: Record[] | undefined, bubbleDat
   const highestItem = data.reduce((max, current) => (current?.y > max?.y ? current : max), data[0]);
   const highestItemRadius = highestItem?.r || 0;
 
-  const yAxisContainsFractions = data?.some(row => !Number.isInteger(row.y));
-
   return {
     responsive: true,
     maintainAspectRatio: false,
@@ -116,11 +115,8 @@ function chartOptions(props: Props, updatedData: Record[] | undefined, bubbleDat
           display: false
         },
         afterDataLimits: function(axis) {
-          // Capture the max value for dynamic stepSize calculation
-          const yAxisMax = axis.max;
-          // Prevent chartJS from showing fractions on the y-axis when there aren't any.
-          (axis.options as any).ticks.stepSize =  
-            !yAxisContainsFractions && yAxisMax < 10 ? 1 : undefined
+          //Disable fractions unless they exist in the data.
+          setYAxisStepSize(axis, props.results, [props.yAxis], props.dps);
         },
         ticks: {
           padding: firstItemRadius          

--- a/src/components/vanilla/charts/LineChart/index.tsx
+++ b/src/components/vanilla/charts/LineChart/index.tsx
@@ -30,6 +30,7 @@ import formatValue from '../../../util/format';
 import formatDateTooltips from '../../../util/formatDateTooltips';
 import hexToRgb from '../../../util/hexToRgb';
 import { parseTime } from '../../../util/timezone';
+import { setYAxisStepSize } from '../../../util/chartjs/common';
 import Container from '../../Container';
 
 ChartJS.register(
@@ -121,12 +122,19 @@ export default (props: Props) => {
           grid: {
             display: false,
           },
-          ticks: {
-            precision: 0,
-          },
           title: {
             display: !!props.yAxisTitle,
             text: props.yAxisTitle,
+          },
+          callback: function (value: number) {
+            return formatValue(
+              value.toString(), 
+              { type: 'number' }
+            )
+          },
+          afterDataLimits: function(axis) {
+            //Disable fractions unless they exist in the data.
+            setYAxisStepSize(axis, props.results, [...props.metrics], props.dps);
           },
         },
         x: {

--- a/src/components/vanilla/charts/ScatterChart/index.tsx
+++ b/src/components/vanilla/charts/ScatterChart/index.tsx
@@ -22,6 +22,7 @@ import { Scatter } from 'react-chartjs-2';
 import { COLORS, EMB_FONT, LIGHT_FONT, SMALL_FONT_SIZE, DATE_DISPLAY_FORMATS } from '../../../constants';
 import formatValue from '../../../util/format';
 import hexToRgb from '../../../util/hexToRgb';
+import { setYAxisStepSize } from '../../../util/chartjs/common';
 
 ChartJS.register(
   CategoryScale,
@@ -89,8 +90,7 @@ export default (props: Props) => {
 function chartOptions(props: Props, scatterData: ChartData<'scatter'>): ChartOptions<'scatter'> {
 
     const datasets = scatterData.datasets;
-    const yAxisContainsFractions = datasets?.some((dataset) => dataset.data.some(row => row && typeof row === 'object' && 'y' in row && !Number.isInteger(row.y)));
-
+    
     return {
         responsive: true,
         maintainAspectRatio: false,
@@ -105,11 +105,8 @@ function chartOptions(props: Props, scatterData: ChartData<'scatter'>): ChartOpt
                     display: false
                 },
                 afterDataLimits: function(axis) {
-                    // Capture the max value for dynamic stepSize calculation
-                    const yAxisMax = axis.max;
-                    // Prevent chartJS from showing fractions on the y-axis when there aren't any.
-                    (axis.options as any).ticks.stepSize =  
-                    !yAxisContainsFractions && yAxisMax < 10 ? 1 : undefined
+                    //Disable fractions unless they exist in the data.
+                    setYAxisStepSize(axis, props.results, [...props.metrics], props.dps)
                 },
                 title: {
                     display: !!props.yAxisTitle,

--- a/src/components/vanilla/charts/StackedAreaChart/index.tsx
+++ b/src/components/vanilla/charts/StackedAreaChart/index.tsx
@@ -23,6 +23,7 @@ import formatValue from '../../../util/format';
 import formatDateTooltips from '../../../util/formatDateTooltips'
 import getStackedChartData, { Props as GeneralStackedChartDataProps } from '../../../util/getStackedChartData';
 import Container from '../../Container';
+import { setYAxisStepSize } from '../../../util/chartjs/common';
 
 ChartJS.register(
   CategoryScale,
@@ -103,13 +104,21 @@ export default (props: Props) => {
           },
           ticks: {
             callback: function (value) {
-              return props.displayAsPercentage ? `${value}%` : value;
+              return props.displayAsPercentage 
+                ? `${value}%` 
+                : formatValue(
+                    value.toString(), 
+                    { type: 'number' }
+                );
             }
           },
           title: {
             display: !!props.yAxisTitle,
             text: props.yAxisTitle
-          }
+          },
+          afterDataLimits: function(axis) {
+            setYAxisStepSize(axis, props.results, [props.metric], props.dps)
+          },
         },
         x: {
           grid: {

--- a/src/models/cubes/customers.cube.yml
+++ b/src/models/cubes/customers.cube.yml
@@ -40,6 +40,24 @@ cubes:
         type: count
         title: '# of customers'
 
+        # Measure for testing negative values
+      - name: negative_values
+        sql: (-1 * (RANDOM() * 100)) + 50
+        type: number
+        title: 'Negative Value'
+
+      # Measure for testing decimal values
+      - name: decimal_values
+        sql: (RANDOM() * 5)
+        type: number
+        title: 'Decimal Value'
+      
+      # Measure for testing whole numbers less than 5
+      - name: small_numbers
+        sql: FLOOR(RANDOM() * 5)
+        type: number
+        title: 'Whole Numbers < 5'
+
     joins:
       - name: orders # the name of the data model to join to (not the table)
         sql: '{CUBE}.id = {orders}.customer_id'


### PR DESCRIPTION
- Chart axes are now formatted (e.g. will appear as 2,000 rather than 2000)
- Logic added to deal with small number fractions: chartJS would previously add a fractional stepsize even if the data only contained whole numbers.  Now it shows fractions only if the data contains fractions, unless the user specifies a specific dp. 
- Bug fixed whereby stacked charts would always show whole numbers even if the data contained fractions


https://github.com/user-attachments/assets/9835aeb0-f389-4a43-bff0-fb726daeeda9


