### PR TITLE
Non-stacked option added to stacked bar charts.

### DIFF
--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -59,6 +59,8 @@ export default function getBarChartOptions({
   xAxisTitle = '',
   yAxisTitle = '',
   displayAsPercentage = false,
+  isGroupedBar,
+  stackBars,  
 }: Partial<Props> & {
   lineMetrics?: Measure[];
   metric?: Measure;
@@ -71,7 +73,10 @@ export default function getBarChartOptions({
   stacked?: boolean;
   xAxisTitle?: string;
   yAxisTitle?: string;
+  isGroupedBar?: boolean;
+  stackBars?: boolean;
 }): ChartOptions<'bar' | 'line'> {
+
   return {
     responsive: true,
     maintainAspectRatio: false,
@@ -86,7 +91,11 @@ export default function getBarChartOptions({
         grid: {
           display: false,
         },
-        max: displayAsPercentage && !displayHorizontally ? 100 : undefined,
+        max: (displayAsPercentage && !displayHorizontally) 
+          ? (isGroupedBar 
+              ? (stackBars ? 100 : undefined) 
+              : 100)
+          : undefined,
         afterDataLimits: function (axis) {
           //Disable fractions unless they exist in the data.
           const metricsGroup = [
@@ -139,7 +148,11 @@ export default function getBarChartOptions({
         grid: {
           display: false,
         },
-        max: displayAsPercentage && displayHorizontally ? 100 : undefined,
+        max: displayAsPercentage && displayHorizontally 
+          ? (isGroupedBar 
+              ? stackBars ? 100 : undefined
+              : 100)
+          : undefined,
         ticks: {
           //https://www.chartjs.org/docs/latest/axes/labelling.html
           callback: function (value) {

--- a/src/components/util/getStackedChartData.ts
+++ b/src/components/util/getStackedChartData.ts
@@ -14,7 +14,7 @@ export type Props = {
   dps?: number;
   ds?: Dataset;
   granularity?: Granularity;
-  isTSStackedBarChart?: boolean;
+  isTSGroupedBarChart?: boolean;
   maxSegments?: number;
   metric: Measure;
   results: DataResponse;
@@ -29,6 +29,8 @@ export type Props = {
   xAxisTitle?: string;
   yAxisMin?: number;
   yAxisTitle?: string;
+  isGroupedBar?: boolean;
+  stackBars?: boolean;
 };
 
 type Options = {
@@ -54,7 +56,7 @@ export default function getStackedChartData(
     showTotals,
     totals,
     useCustomDateFormat,
-    xAxis,
+    xAxis
   } = props;
   const labels = [...new Set(results?.data?.map((d: Record) => d[xAxis?.name || '']))] as string[];
   const segments = segmentsToInclude();

--- a/src/components/vanilla/charts/BubbleMapChart/BubbleMapChart.emb.ts
+++ b/src/components/vanilla/charts/BubbleMapChart/BubbleMapChart.emb.ts
@@ -5,7 +5,7 @@ import Component from './index';
 
 export const meta = {
   name: 'BubbleMapChart',
-  label: 'Bubble Map Chart',
+  label: 'Bubble map chart',
   classNames: ['inside-card'],
   category: 'Charts: essentials',
   inputs: [

--- a/src/components/vanilla/charts/KPIChart/KPIChartText.emb.ts
+++ b/src/components/vanilla/charts/KPIChart/KPIChartText.emb.ts
@@ -33,7 +33,7 @@ export const meta = {
     {
       name: 'metric',
       type: 'measure',
-      label: 'Sort values by',
+      label: 'Show top value by',
       config: {
         dataset: 'ds',
       },

--- a/src/components/vanilla/charts/LineChart/LineChart.emb.ts
+++ b/src/components/vanilla/charts/LineChart/LineChart.emb.ts
@@ -5,7 +5,7 @@ import Component from './index';
 
 export const meta = {
   name: 'LineChart',
-  label: 'Multi-metric line (time-series)',
+  label: 'Line chart (time-series)',
   classNames: ['inside-card'],
   category: 'Charts: time-series',
   inputs: [

--- a/src/components/vanilla/charts/StackedAreaChart/MultiDimensionLineChart.emb.ts
+++ b/src/components/vanilla/charts/StackedAreaChart/MultiDimensionLineChart.emb.ts
@@ -5,7 +5,7 @@ import Component from './index';
 
 export const meta = {
   name: 'MultiDimensionLineChart',
-  label: 'Multi-dimension line (time-series)',
+  label: 'Grouped line chart (time-series)',
   classNames: ['inside-card'],
   category: 'Charts: time-series',
   inputs: [
@@ -28,7 +28,7 @@ export const meta = {
     {
       name: 'segment',
       type: 'dimension',
-      label: 'Segment',
+      label: 'Grouping',
       config: {
         dataset: 'ds',
       },

--- a/src/components/vanilla/charts/StackedBarChart/StackedBarChart.emb.ts
+++ b/src/components/vanilla/charts/StackedBarChart/StackedBarChart.emb.ts
@@ -5,7 +5,7 @@ import Component from './index';
 
 export const meta = {
   name: 'StackedBarChart',
-  label: 'Stacked bar chart',
+  label: 'Grouped bar chart',
   classNames: ['inside-card'],
   category: 'Charts: essentials',
   inputs: [
@@ -27,7 +27,7 @@ export const meta = {
     {
       name: 'segment',
       type: 'dimension',
-      label: 'Segment',
+      label: 'Grouping',
       config: {
         dataset: 'ds',
       },
@@ -66,6 +66,13 @@ export const meta = {
       category: 'Chart settings',
     },
     {
+      name: 'stackBars',
+      type: 'boolean',
+      label: 'Stack bars',
+      defaultValue: true,
+      category: 'Chart settings',
+    },
+    {
       name: 'showLegend',
       type: 'boolean',
       label: 'Show legend',
@@ -89,7 +96,7 @@ export const meta = {
     {
       name: 'showTotals',
       type: 'boolean',
-      label: 'Show Totals',
+      label: 'Show Totals Above Stacked Bars',
       defaultValue: false,
       category: 'Chart settings',
     },
@@ -150,6 +157,7 @@ export default defineComponent(Component, meta, {
 
     return {
       ...inputs,
+      isGroupedBar: true,
       results: loadData({
         from: inputs.ds,
         dimensions: [inputs.xAxis, inputs.segment],

--- a/src/components/vanilla/charts/StackedBarChart/TimeSeriesStackedBarChart.emb.ts
+++ b/src/components/vanilla/charts/StackedBarChart/TimeSeriesStackedBarChart.emb.ts
@@ -5,7 +5,7 @@ import Component from './index';
 
 export const meta = {
   name: 'TimeSeriesStackedBarChart',
-  label: 'Stacked bar chart (time-series)',
+  label: 'Grouped bar chart (time-series)',
   category: 'Charts: time-series',
   classNames: ['inside-card'],
   inputs: [
@@ -35,7 +35,7 @@ export const meta = {
     {
       name: 'segment',
       type: 'dimension',
-      label: 'Segment',
+      label: 'Grouping',
       config: {
         dataset: 'ds',
       },
@@ -65,6 +65,13 @@ export const meta = {
       category: 'Chart settings',
     },
     {
+      name: 'stackBars',
+      type: 'boolean',
+      label: 'Stack bars',
+      defaultValue: true,
+      category: 'Chart settings',
+    },
+    {
       name: 'showLegend',
       type: 'boolean',
       label: 'Show legend',
@@ -88,7 +95,7 @@ export const meta = {
     {
       name: 'showTotals',
       type: 'boolean',
-      label: 'Show Totals',
+      label: 'Show Totals Above Stacked Bars',
       defaultValue: false,
       category: 'Chart settings',
     },
@@ -133,7 +140,8 @@ export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
     return {
       ...inputs,
-      isTSStackedBarChart: true,
+      isGroupedBar: true,
+      isTSGroupedBarChart: true,
       reverseXAxis: true,
       useCustomDateFormat: true,
       results: loadData({

--- a/src/components/vanilla/charts/StackedBarChart/index.tsx
+++ b/src/components/vanilla/charts/StackedBarChart/index.tsx
@@ -55,10 +55,10 @@ export default (props: Props) => {
 
   //add missing dates to time-series stacked barcharts
   const { fillGaps } = useTimeseries(props, 'desc');
-  const { results, isTSStackedBarChart } = props;
+  const { results, isTSGroupedBarChart } = props;
   const updatedProps = {
     ...props,
-    results: isTSStackedBarChart
+    results: isTSGroupedBarChart
       ? { ...props.results, data: results?.data?.reduce(fillGaps, []) }
       : props.results,
   };
@@ -89,7 +89,7 @@ export default (props: Props) => {
     <Container {...props} className="overflow-y-hidden">
       <Bar
         height="100%"
-        options={getBarChartOptions({ ...updatedProps, stacked: true })}
+        options={getBarChartOptions({ ...updatedProps, stacked: props.stackBars })}
         data={
           getStackedChartData(updatedProps, datasetsMeta) as ChartData<'bar', number[], unknown>
         }


### PR DESCRIPTION
- A 'stacked' boolean input has been added to the stacked bar chart. When set to true, the bars are stacked. When set to false, the bars are grouped together (based on the x-axis value), but not-stacked. 
- % option modified so, when grouped, it doesn't set a max-y-value of 100.  

Additionally, stacked charts name updated to "grouped charts". 

- I've done this to create a consistent naming convention for the scenario where we have different chart options for multi-metric and multi-dimension data inputs. Multi-metric is now the standard (e.g. bar chart, line chart). Multi-dimension (e.g. stacked bar chart, multi-dimension line chart) is now 'grouped'.

- I've discovered an issue for the 'show totals above stacked bars' option. When "display as %" is selected, the total should show 100 but instead shows the original total. We can fix this in a separate MR. 
