### PR TITLE
Move Pie Charts to Themes

### DIFF
--- a/src/components/util/chartjs/common.ts
+++ b/src/components/util/chartjs/common.ts
@@ -1,7 +1,7 @@
 import { DataResponse, Measure } from '@embeddable.com/core';
 import { Chart as ChartJS, Scale, CoreScaleOptions } from 'chart.js';
 import { containsFractions } from '../dataUtils';
-import { Theme } from '../../../defaulttheme';
+import { Theme, ChartType } from '../../../defaulttheme';
 
 export function setYAxisStepSize(
   axis: Scale<CoreScaleOptions>,
@@ -19,10 +19,22 @@ export function setYAxisStepSize(
   }
 }
 
-export const setChartJSDefaults = (theme: Theme) => {
+export const setChartJSDefaults = (theme: Theme, chartType?: ChartType) => {
+  if (!theme || !theme.charts) {
+    return;
+  }
+
+  // Some charts vary, so we check for chart type and if it exists, set some values
+  let fontSize = theme.charts.font.size;
+  if (chartType && theme.charts[chartType]) {
+    if (theme.charts[chartType].font?.size) {
+      fontSize = theme.charts[chartType].font.size;
+    }
+  }
   // We don't need to return Chartjs defaults as we are mutating the global object
-  ChartJS.defaults.font.size = theme.chartFont.size;
-  ChartJS.defaults.color = theme.chartFont.color;
-  ChartJS.defaults.font.family = theme.chartFont.family;
-  ChartJS.defaults.plugins.tooltip.enabled = theme.chartOptions.toolTipEnabled;
+  ChartJS.defaults.font.size = fontSize;
+  ChartJS.defaults.color = theme.charts.font.color;
+  ChartJS.defaults.font.family = theme.charts.font.family;
+  ChartJS.defaults.plugins.tooltip.enabled = theme.charts.options.toolTipEnabled;
+  ChartJS.defaults.plugins.tooltip.usePointStyle = true;
 };

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -18,6 +18,7 @@ import { Chart } from 'react-chartjs-2';
 import formatValue from '../../../../util/format';
 import getBarChartOptions from '../../../../util/getBarChartOptions';
 import { setChartJSDefaults } from '../../../../util/chartjs/common';
+import { Theme } from '../../../../../defaulttheme';
 
 ChartJS.register(
   CategoryScale,
@@ -52,7 +53,7 @@ type Props = {
   granularity?: Granularity;
   showSecondYAxis?: boolean;
   secondAxisTitle?: string;
-  theme?: any;
+  theme: Theme;
 };
 
 export default function BarChart({ ...props }: Props): React.JSX.Element {
@@ -68,7 +69,10 @@ export default function BarChart({ ...props }: Props): React.JSX.Element {
 
 function chartData(props: Props): ChartData<'bar' | 'line'> {
   const { results, xAxis, metrics, granularity, lineMetrics, showSecondYAxis, theme } = props;
-  const { chartColors, dateFormats } = theme;
+  const {
+    charts: { colors },
+    dateFormats,
+  } = theme;
   setChartJSDefaults(theme);
 
   let dateFormat: string | undefined;
@@ -97,7 +101,7 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
       borderRadius: 4,
       label: metric.title,
       data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
-      backgroundColor: chartColors[i % chartColors.length],
+      backgroundColor: colors[i % colors.length],
       order: 1,
     })) || [];
 
@@ -106,8 +110,8 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
     lineMetrics?.map((metric, i) => ({
       label: metric.title,
       data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
-      backgroundColor: chartColors[metrics.length + (i % chartColors.length)],
-      borderColor: chartColors[metrics.length + (i % chartColors.length)],
+      backgroundColor: colors[metrics.length + (i % colors.length)],
+      borderColor: colors[metrics.length + (i % colors.length)],
       cubicInterpolationMode: 'monotone' as const,
       pointRadius: 2,
       pointHoverRadius: 3,

--- a/src/components/vanilla/charts/BarChart/index.tsx
+++ b/src/components/vanilla/charts/BarChart/index.tsx
@@ -4,6 +4,7 @@ import { useOverrideConfig } from '@embeddable.com/react';
 import useTimeseries from '../../../hooks/useTimeseries';
 import Container from '../../Container';
 import BarChart from './components/BarChart';
+import defaultTheme, { Theme } from '../../../../defaulttheme';
 
 type Props = {
   clientContext?: any;
@@ -28,8 +29,10 @@ type Props = {
   yAxisTitle?: string;
   showSecondYAxis?: boolean;
   secondAxisTitle?: string;
-  theme?: any;
+  theme?: Theme;
 };
+
+type PropsWithRequiredtheme = Props & { theme: Theme };
 
 export default (props: Props): React.JSX.Element => {
   // Get theme for use in component
@@ -41,9 +44,9 @@ export default (props: Props): React.JSX.Element => {
   const { results, isTSBarChart } = props;
 
   // Update props with theme and filled gaps
-  const updatedProps: Props = {
+  const updatedProps: PropsWithRequiredtheme = {
     ...props,
-    theme,
+    theme: theme || defaultTheme,
     results: isTSBarChart
       ? { ...props.results, data: results?.data?.reduce(fillGaps, []) }
       : props.results,

--- a/src/components/vanilla/charts/PieChart/index.tsx
+++ b/src/components/vanilla/charts/PieChart/index.tsx
@@ -16,9 +16,11 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 import React, { useRef, useState } from 'react';
 import { Pie, getElementAtEvent } from 'react-chartjs-2';
 
-import { COLORS, EMB_FONT, LIGHT_FONT, SMALL_FONT_SIZE } from '../../../constants';
 import formatValue from '../../../util/format';
 import Container from '../../Container';
+import { useOverrideConfig } from '@embeddable.com/react';
+import { setChartJSDefaults } from '../../../util/chartjs/common';
+import { Theme } from '../../../../defaulttheme';
 
 ChartJS.register(
   ChartDataLabels,
@@ -32,12 +34,6 @@ ChartJS.register(
   Legend,
 );
 
-ChartJS.defaults.font.size = parseInt(SMALL_FONT_SIZE);
-ChartJS.defaults.color = LIGHT_FONT;
-ChartJS.defaults.font.family = EMB_FONT;
-ChartJS.defaults.plugins.tooltip.enabled = true;
-ChartJS.defaults.plugins.tooltip.usePointStyle = true;
-
 type Props = {
   results: DataResponse;
   title: string;
@@ -50,12 +46,27 @@ type Props = {
   displayAsPercentage?: boolean;
   enableDownloadAsCSV?: boolean;
   onClick: (args: { slice: string | null; metric: string | null }) => void;
+  theme?: Theme;
 };
 
 type Record = { [p: string]: string };
 
 export default (props: Props) => {
   const { results, title, enableDownloadAsCSV, maxSegments, metric, slice, onClick } = props;
+
+  // Get theme for use in component
+  const overrides: any = useOverrideConfig();
+  const { theme } = overrides;
+
+  // Set ChartJS defaults
+  const { chartColors, dateFormats } = theme;
+  setChartJSDefaults(theme, 'pie');
+
+  // Add the theme to props
+  const updatedProps: Props = {
+    ...props,
+    theme,
+  };
 
   const [clickedIndex, setClickedIndex] = useState<number | null>(null);
 
@@ -94,8 +105,8 @@ export default (props: Props) => {
     <Container {...props} className="overflow-y-hidden">
       <Pie
         height="100%"
-        options={chartOptions(props)}
-        data={chartData(props)}
+        options={chartOptions(updatedProps)}
+        data={chartData(updatedProps)}
         ref={chartRef}
         onClick={handleClick}
       />
@@ -200,7 +211,7 @@ function chartData(props: Props) {
     datasets: [
       {
         data: counts,
-        backgroundColor: COLORS,
+        backgroundColor: props.theme ? props.theme.charts.colors : [],
         borderColor: '#fff',
         borderWeight: 5,
       },

--- a/src/defaulttheme.ts
+++ b/src/defaulttheme.ts
@@ -1,47 +1,99 @@
+import { Chart } from 'chart.js';
+
+export type ChartType =
+  | 'bar'
+  | 'line'
+  | 'pie'
+  | 'doughnut'
+  | 'radar'
+  | 'polarArea'
+  | 'bubble'
+  | 'scatter';
+
 export type Theme = {
   'brand-color-primary': string;
   'brand-color-secondary': string;
-  chartColors: string[];
-  chartFont: {
-    color: string;
-    family: string;
-    size: number;
+  charts: {
+    colors: string[];
+    font: {
+      color: string;
+      family: string;
+      size: number;
+    };
+    options: {
+      toolTipEnabled: boolean;
+      usePointStyle: boolean;
+    };
+  } & {
+    [key in ChartType]?: any;
   };
-  chartOptions: {
-    toolTipEnabled: boolean;
+  dateFormats: {
+    year: string;
+    quarter: string;
+    month: string;
+    day: string;
+    week: string;
+    hour: string;
+    minute: string;
+    second: string;
   };
 };
+
+type ThemeDeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? ThemeDeepPartial<T[P]> : T[P];
+};
+
+export type ThemePartial = ThemeDeepPartial<Theme>;
 
 /*
  * This will require changes to the typescript build process to be accessible outside of
  * the package. For now, we will just export the type.
  */
-const theme: Theme = {
+const defaultTheme: Theme = {
   'brand-color-primary': '#6778DE',
   'brand-color-secondary': '#FF997C',
-  chartColors: [
-    '#6778DE',
-    '#FF997C',
-    '#9EA4F4',
-    '#B8B8D1',
-    '#FF6B6C',
-    '#FFC145',
-    '#9DC7FF',
-    '#FF805B',
-    '#CD9FFF',
-    '#E6DEDE',
-    '#FFA6A6',
-    '#FFD98D',
-  ],
-  chartFont: {
-    color: '#888',
-    family:
-      '-apple-system, "system-ui", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
-    size: 14,
+  charts: {
+    colors: [
+      '#6778DE',
+      '#FF997C',
+      '#9EA4F4',
+      '#B8B8D1',
+      '#FF6B6C',
+      '#FFC145',
+      '#9DC7FF',
+      '#FF805B',
+      '#CD9FFF',
+      '#E6DEDE',
+      '#FFA6A6',
+      '#FFD98D',
+    ],
+    font: {
+      color: '#888',
+      family:
+        '-apple-system, "system-ui", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+      size: 14,
+    },
+    options: {
+      toolTipEnabled: true,
+      usePointStyle: true,
+    },
+    bar: {},
+    pie: {
+      font: {
+        size: 12,
+      },
+    },
   },
-  chartOptions: {
-    toolTipEnabled: true,
+  dateFormats: {
+    year: 'yyyy',
+    quarter: 'MMM yy',
+    month: 'MMM yy',
+    day: 'd MMM',
+    week: 'd MMM',
+    hour: 'eee HH:mm',
+    minute: 'eee HH:mm',
+    second: 'HH:mm:ss',
   },
 };
 
-export default theme;
+export default defaultTheme;


### PR DESCRIPTION
**Note: this is being merged to develop, not main**

This PR moves the pie chart away from using `constants.ts` and instead uses the theme values being passed in via the client repo (not currently visible, will fix that shortly so people can see what I'm doing over there 😁 )

I had to tweak a few things in the bar chart to go along with the changes I realized I needed to make to get the pie chart working. This will happen a bit here and there as we get more charts up and running and realize we need to tweak the theme structure. You can see the tweaks to the theme structure in the default file (the celtics file is in my client repo, see above)

**Acceptance Criteria**

- Code looks good
- Pie chart changes color with theme change (see screenshots)
- Pie chart changes font with theme change (see screenshots)

**Screenshots**

<img width="749" alt="image" src="https://github.com/user-attachments/assets/17b8cb83-8a9f-45e9-a758-5fbc549a8cfc" />
<img width="761" alt="image" src="https://github.com/user-attachments/assets/84dfe7c4-7c1e-4e0f-8dc5-9bf9ecbbf938" />

