### PR TITLE
Change Comparison Line Chart to Use Themes

### DIFF
--- a/src/components/vanilla/charts/BubbleChart/index.tsx
+++ b/src/components/vanilla/charts/BubbleChart/index.tsx
@@ -57,7 +57,6 @@ type Props = {
 };
 
 type PropsWithRequiredTheme = Props & { theme: Theme };
-
 type Record = { [p: string]: any };
 
 export default (props: Props) => {
@@ -93,10 +92,13 @@ function chartOptions(
   updatedData: Record[] | undefined,
   bubbleData: ChartData<'bubble'>,
 ): ChartOptions<'bubble'> {
-  const { theme } = props;
+  let { theme } = props;
+  if (!theme) {
+    theme = defaultTheme;
+  }
 
   // Set ChartJS defaults
-  setChartJSDefaults(theme ? theme : defaultTheme, 'bubble');
+  setChartJSDefaults(theme, 'bubble');
 
   const data = bubbleData.datasets[0].data;
 
@@ -144,7 +146,7 @@ function chartOptions(
         time: {
           round: props.granularity,
           isoWeekday: true,
-          displayFormats: theme ? theme.dateFormats : defaultTheme.dateFormats,
+          displayFormats: theme.dateFormats,
           unit: props.granularity,
         },
         grid: {
@@ -250,9 +252,7 @@ function chartData(
       {
         label: props.yAxis.title,
         data: ndata,
-        backgroundColor: theme
-          ? hexToRgb(theme.charts.colors[0], 0.8)
-          : hexToRgb(defaultTheme.charts.colors[0], 0.8),
+        backgroundColor: hexToRgb(theme.charts.colors[0], 0.8),
       },
     ],
   };

--- a/src/components/vanilla/charts/PieChart/index.tsx
+++ b/src/components/vanilla/charts/PieChart/index.tsx
@@ -20,7 +20,7 @@ import formatValue from '../../../util/format';
 import Container from '../../Container';
 import { useOverrideConfig } from '@embeddable.com/react';
 import { setChartJSDefaults } from '../../../util/chartjs/common';
-import { Theme } from '../../../../defaulttheme';
+import defaultTheme, { Theme } from '../../../../defaulttheme';
 
 ChartJS.register(
   ChartDataLabels,
@@ -46,9 +46,9 @@ type Props = {
   displayAsPercentage?: boolean;
   enableDownloadAsCSV?: boolean;
   onClick: (args: { slice: string | null; metric: string | null }) => void;
-  theme?: Theme;
 };
 
+type PropsWithRequiredTheme = Props & { theme: Theme };
 type Record = { [p: string]: string };
 
 export default (props: Props) => {
@@ -56,13 +56,16 @@ export default (props: Props) => {
 
   // Get theme for use in component
   const overrides: { theme: Theme } = useOverrideConfig() as { theme: Theme };
-  const { theme } = overrides;
+  let { theme } = overrides;
+  if (!theme) {
+    theme = defaultTheme;
+  }
 
   // Set ChartJS defaults
   setChartJSDefaults(theme, 'pie');
 
   // Add the theme to props
-  const updatedProps: Props = {
+  const updatedProps: PropsWithRequiredTheme = {
     ...props,
     theme,
   };
@@ -187,8 +190,8 @@ function mergeLongTail({ results, slice, metric, maxSegments }: Props) {
   return newData;
 }
 
-function chartData(props: Props) {
-  const { maxSegments, results, metric, slice, displayAsPercentage } = props;
+function chartData(props: PropsWithRequiredTheme) {
+  const { maxSegments, results, metric, slice, displayAsPercentage, theme } = props;
   const labelsExceedMaxSegments = maxSegments && maxSegments < (results?.data?.length || 0);
   const newData = labelsExceedMaxSegments ? mergeLongTail(props) : results.data;
 
@@ -210,7 +213,7 @@ function chartData(props: Props) {
     datasets: [
       {
         data: counts,
-        backgroundColor: props.theme ? props.theme.charts.colors : [],
+        backgroundColor: theme.charts.colors,
         borderColor: '#fff',
         borderWeight: 5,
       },

--- a/src/defaulttheme.ts
+++ b/src/defaulttheme.ts
@@ -83,6 +83,11 @@ const defaultTheme: Theme = {
         size: 12,
       },
     },
+    line: {
+      font: {
+        size: 12,
+      },
+    },
     pie: {
       font: {
         size: 12,


### PR DESCRIPTION
**Note: this is being merged to `develop` and not `main`**

This moves the table charts away from constants and instead uses the new theming system.

This and similar PRs are going to be merged to dev without additional review, which will instead happen when all charts and controls are converted.