### PR TITLE
Update Table to Reset to Page 1 if Variables Change

### DIFF
--- a/src/components/vanilla/charts/TableChart/TableChart.emb.ts
+++ b/src/components/vanilla/charts/TableChart/TableChart.emb.ts
@@ -107,9 +107,12 @@ export const meta = {
 export default defineComponent<
   Props,
   typeof meta,
-  { maxRowsFit: number; sort: OrderBy[]; page: number }
+  { maxRowsFit: number; sort: OrderBy[]; page: number; prevVariableValues: Record<string, any> }
 >(Component, meta, {
   props: (inputs: Inputs<typeof meta>, [state]) => {
+    const currVariableValues = inputs?.ds?.variableValues || {};
+    const prevVariableValues = state?.prevVariableValues || {};
+
     const limit =
       inputs.maxPageRows || state?.maxRowsFit
         ? Math.min(inputs.maxPageRows || 1000, Math.max(state?.maxRowsFit, 1) || 1000)
@@ -132,6 +135,12 @@ export default defineComponent<
         property: inputs.defaultSort,
         direction: defaultSortDirection,
       });
+    }
+
+    // Deep compare the variable values to determine if the dataset has changed
+    if (state && JSON.stringify(currVariableValues) !== JSON.stringify(prevVariableValues)) {
+      state.prevVariableValues = currVariableValues;
+      state.page = 0;
     }
 
     return {

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -19,7 +19,12 @@ export type Props = {
   minColumnWidth?: number;
 };
 
-type Meta = { page: number; maxRowsFit: number; sort: OrderBy[] };
+type Meta = {
+  page: number;
+  maxRowsFit: number;
+  sort: OrderBy[];
+  prevVariableValues: Record<string, any>;
+};
 
 export default (props: Props) => {
   const { columns, results } = props;
@@ -30,6 +35,7 @@ export default (props: Props) => {
     page: 0,
     maxRowsFit: 0,
     sort: props.defaultSort,
+    prevVariableValues: {},
   }) as [Meta, (f: (m: Meta) => Meta) => void];
 
   const calculateMaxRowFix = useCallback(


### PR DESCRIPTION
**Description**

If you have a table that's linked to a variable, and you're on, say, page 5 of the table, and you change the variable to something that reduces the table length to only one or two pages, then you'll get a table showing nothing because you're on page 5 of a 2 page table.

See this video: https://us06web.zoom.us/clips/share/A2F3MRY2dHk2T3VrTFFsSzdTdmIxaTZ2YjhRAQ

**Desired Behavior**

If the table's dataset changes (other than for paging purposes), reset the page to zero.

**Acceptance Criteria**

- Code should look good
- Table should reset to page 1 if any variable changes happen

**Video Evidence**

https://www.loom.com/share/a61f00baf0c340c1aa7f16316788911a?sid=e33d2dff-7203-4606-8502-212974fdb861
