### PR TITLE
Adds missing title/desc to Bubble Map component

### DIFF
--- a/src/components/vanilla/charts/BubbleMapChart/BubbleMapChart.emb.ts
+++ b/src/components/vanilla/charts/BubbleMapChart/BubbleMapChart.emb.ts
@@ -37,6 +37,20 @@ export const meta = {
       category: 'Chart Data',
     },
     {
+      name: 'title',
+      type: 'string',
+      label: 'Title',
+      description: 'The title for the chart',
+      category: 'Chart settings',
+    },
+    {
+      name: 'description',
+      type: 'string',
+      label: 'Description',
+      description: 'The description for the chart',
+      category: 'Chart settings',
+    },
+    {
       name: 'clusterRadius',
       type: 'number',
       label: 'Cluster Radius',

--- a/src/components/vanilla/charts/BubbleMapChart/index.tsx
+++ b/src/components/vanilla/charts/BubbleMapChart/index.tsx
@@ -40,6 +40,7 @@ type Props = {
   bubblePlacement: Dimension;
   clusterRadius?: number;
   customTileSet?: string;
+  description?: string;
   ds?: Dataset;
   enableDownloadAsCSV?: boolean;
   enableDownloadAsPNG?: boolean;
@@ -48,6 +49,7 @@ type Props = {
   metric?: Measure;
   results: DataResponse;
   showTooltips?: boolean;
+  title?: string;
 };
 
 // Child Component - used to auto-zoom the map to fit all markers (rerenders if they change)


### PR DESCRIPTION
**Description**
The Bubble Map component was missing the title/description inputs that most of the rest of our charts have.

**Solution**
Add them!

**Acceptance Criteria**
- They're there
- They work

**Screenshots**
<img width="435" alt="image" src="https://github.com/user-attachments/assets/68228af3-7b98-4649-af43-657b4591ba04" />
