### PR TITLE
Update Date Tooltips to Use Theme

### DIFF
--- a/src/components/util/formatDateTooltips.ts
+++ b/src/components/util/formatDateTooltips.ts
@@ -2,8 +2,6 @@ import { Granularity } from '@embeddable.com/core';
 import { format } from 'date-fns';
 import { Theme } from '../../defaulttheme';
 
-// import { DATE_DISPLAY_FORMATS } from '../constants';
-
 export default function formatDateTooltips(lines: any[], granularity: Granularity, theme: Theme) {
   const linesList = lines.map((line) => line?.parsed?.x?.valueOf());
   const set = [...new Set(linesList)];

--- a/src/components/util/formatDateTooltips.ts
+++ b/src/components/util/formatDateTooltips.ts
@@ -1,20 +1,16 @@
 import { Granularity } from '@embeddable.com/core';
 import { format } from 'date-fns';
+import { Theme } from '../../defaulttheme';
 
-import { DATE_DISPLAY_FORMATS } from '../constants';
+// import { DATE_DISPLAY_FORMATS } from '../constants';
 
-export default function formatDateTooltips(lines: any[], granularity: Granularity) {
+export default function formatDateTooltips(lines: any[], granularity: Granularity, theme: Theme) {
   const linesList = lines.map((line) => line?.parsed?.x?.valueOf());
   const set = [...new Set(linesList)];
   if (set.length === 1 && set[0] === undefined) {
     return;
   }
   return set
-    .map((date) =>
-      format(
-        new Date(date),
-        DATE_DISPLAY_FORMATS[granularity as keyof typeof DATE_DISPLAY_FORMATS],
-      ),
-    )
+    .map((date) => format(new Date(date), theme.dateFormats[granularity]))
     .filter((v) => !!v);
 }

--- a/src/components/vanilla/charts/CompareLineChart/index.tsx
+++ b/src/components/vanilla/charts/CompareLineChart/index.tsx
@@ -245,7 +245,7 @@ export default (propsInitial: Props) => {
         },
         tooltip: {
           callbacks: {
-            title: (lines: any[]) => formatDateTooltips(lines, props.granularity),
+            title: (lines: any[]) => formatDateTooltips(lines, props.granularity, theme),
             label: function (context) {
               //metric needed for formatting
               const metricIndex = context.datasetIndex % props.metrics.length;

--- a/src/components/vanilla/charts/LineChart/index.tsx
+++ b/src/components/vanilla/charts/LineChart/index.tsx
@@ -210,7 +210,7 @@ export default (props: Props) => {
               }
               return label;
             },
-            title: (lines: any[]) => formatDateTooltips(lines, updatedProps.granularity),
+            title: (lines: any[]) => formatDateTooltips(lines, updatedProps.granularity, theme),
           },
         },
       },

--- a/src/components/vanilla/charts/StackedAreaChart/index.tsx
+++ b/src/components/vanilla/charts/StackedAreaChart/index.tsx
@@ -179,7 +179,8 @@ export default (props: Props) => {
               }
               return label;
             },
-            title: (lines: any[]) => formatDateTooltips(lines, updatedProps.granularity || 'day'),
+            title: (lines: any[]) =>
+              formatDateTooltips(lines, updatedProps.granularity || 'day', theme),
           },
         },
         datalabels: {


### PR DESCRIPTION
**Note: this is being merged to `develop` and not `main`**

This moves the date tooltips away from constants and instead uses the new theming system.

This and similar PRs are going to be merged to dev without additional review, which will instead happen when all charts and controls are converted.