### PR TITLE
Move Pivot Table to Using Themes

### DIFF
--- a/src/components/vanilla/charts/PivotTable/PivotTable.tsx
+++ b/src/components/vanilla/charts/PivotTable/PivotTable.tsx
@@ -3,64 +3,68 @@ import { Dimension, Measure } from '@embeddable.com/core';
 import TableHead from './components/TableHead';
 import TableRow from './components/TableRow';
 import { SortDirection } from '../../../../enums/SortDirection';
-import { DATE_DISPLAY_FORMATS, REGULAR_FONT_SIZE } from '../../../constants';
 import formatValue from '../../../util/format';
 import { usePivotTable } from './core/usePivotTable';
 import { multisortFn, SortCriteria } from '../../../util/sortFn';
 import { Row } from './core/Row';
+import defaultTheme, { Theme } from '../../../../defaulttheme';
+import { useOverrideConfig } from '@embeddable.com/react';
 
 type Props<T> = {
-  data: T[][];
-  rowDimensions?: Dimension[];
+  aggregateRowDimensions?: boolean;
   columnDimensions?: Dimension[];
-  measures: Measure[];
-  granularity?: string;
-  defaultRowDimensionSortDirection?: SortDirection;
+  columnSortingEnabled?: boolean;
+  data: T[][];
   defaultColumnDimensionSortDirection?: SortDirection;
+  defaultRowDimensionSortDirection?: SortDirection;
+  fontSize?: string;
+  granularity?: string;
+  isRowGroupDefaultExpanded?: boolean;
+  measures: Measure[];
   minColumnWidth?: number;
   minRowDimensionColumnWidth?: number;
   nullValueCharacter?: string;
-  isRowGroupDefaultExpanded?: boolean;
-  // measureVisualizationFormat: MeasureVisualizationFormat;
-  columnSortingEnabled?: boolean;
-  fontSize?: string;
-  aggregateRowDimensions?: boolean;
-}
+  rowDimensions?: Dimension[];
+};
 
 const PivotTable = <T,>({
-  data,
+  aggregateRowDimensions = true,
   columnDimensions,
-  rowDimensions,
-  defaultRowDimensionSortDirection,
-  measures,
-  granularity,
+  columnSortingEnabled = true,
+  data,
   defaultColumnDimensionSortDirection,
+  defaultRowDimensionSortDirection,
+  fontSize = `${defaultTheme.charts.font.size}px`,
+  granularity,
+  isRowGroupDefaultExpanded = true,
+  measures,
   minColumnWidth,
   minRowDimensionColumnWidth,
   nullValueCharacter = '',
-  isRowGroupDefaultExpanded = true,
-  // measureVisualizationFormat,
-  fontSize = REGULAR_FONT_SIZE,
-  columnSortingEnabled = true,
-  aggregateRowDimensions = true
+  rowDimensions,
 }: Props<T>) => {
+  // Get theme for use in component
+  const overrides: { theme: Theme } = useOverrideConfig() as { theme: Theme };
+  let { theme } = overrides;
+  if (!theme) {
+    theme = defaultTheme;
+  }
+  fontSize = `${theme.charts.font.size}px`;
 
   const [sortCriteria, setSortCriteria] = useState<SortCriteria<any>[]>(() => {
     if (!rowDimensions || !defaultRowDimensionSortDirection) {
       return [];
     }
 
-    return [{
-      key: rowDimensions.length === 1 ? rowDimensions[0].name : '__group.key',
-      direction: defaultRowDimensionSortDirection
-    }];
+    return [
+      {
+        key: rowDimensions.length === 1 ? rowDimensions[0].name : '__group.key',
+        direction: defaultRowDimensionSortDirection,
+      },
+    ];
   });
 
-  const {
-    rows,
-    columns,
-    getLeafColumns
-  } = usePivotTable<T>(
+  const { rows, columns, getLeafColumns } = usePivotTable<T>(
     data,
     measures,
     rowDimensions,
@@ -68,29 +72,31 @@ const PivotTable = <T,>({
     {
       aggregateRowDimensions,
       defaultColumnsSort: defaultColumnDimensionSortDirection,
-      granularity
-    }
+      granularity,
+    },
   );
 
   const sortRows = (rows: Row[], sortCriteria: SortCriteria<any>[]): Row[] => {
     const sortedRows = [...rows];
     sortedRows.sort(multisortFn(sortCriteria));
 
-    sortedRows.forEach(row => {
+    sortedRows.forEach((row) => {
       if (row.children?.length) {
         row.children = sortRows(row.children, sortCriteria);
       }
-    })
+    });
 
     return sortedRows;
-  }
+  };
 
   const sortCriteriaWithDataAccessor = useMemo<SortCriteria<any>[]>(() => {
     const nullValueCharacterAsNumber = parseInt(nullValueCharacter, 10);
 
-    return sortCriteria.map(sortCriterion => ({
+    return sortCriteria.map((sortCriterion) => ({
       ...sortCriterion,
-      key: (row: Row) => row.data[sortCriterion.key as string] || (isNaN(nullValueCharacterAsNumber) ? null : nullValueCharacterAsNumber)
+      key: (row: Row) =>
+        row.data[sortCriterion.key as string] ||
+        (isNaN(nullValueCharacterAsNumber) ? null : nullValueCharacterAsNumber),
     }));
   }, [sortCriteria]);
 
@@ -98,10 +104,12 @@ const PivotTable = <T,>({
     return sortRows(rows, sortCriteriaWithDataAccessor);
   }, [rows, sortCriteriaWithDataAccessor]);
 
-
-  const getMeasureByLabel = useMemo(() => (label: string) => {
-    return measures.find(measure => measure.title === label);
-  }, [measures]);
+  const getMeasureByLabel = useMemo(
+    () => (label: string) => {
+      return measures.find((measure) => measure.title === label);
+    },
+    [measures],
+  );
 
   return (
     <table className="min-w-full border-separate border-spacing-0 table-fixed">
@@ -113,18 +121,19 @@ const PivotTable = <T,>({
           enableSorting={columnSortingEnabled}
           sortCriteria={sortCriteria}
           onSortingChange={(columnKey, sortDirection) => {
-            setSortCriteria([{
-              key: columnKey,
-              direction: sortDirection
-            }]);
+            setSortCriteria([
+              {
+                key: columnKey,
+                direction: sortDirection,
+              },
+            ]);
           }}
           fontSize={fontSize}
         />
       </thead>
 
       <tbody className="overflow-y-auto">
-      {
-        sortedRows.map((row => (
+        {sortedRows.map((row) => (
           <TableRow
             key={row.id}
             columns={getLeafColumns()}
@@ -135,27 +144,29 @@ const PivotTable = <T,>({
 
               return (
                 <span style={{ fontSize }}>
-                  {
-                    cellValue === undefined || cellValue === null
-                      ? nullValueCharacter
-                      : formatValue(cellValue, {
+                  {cellValue === undefined || cellValue === null
+                    ? nullValueCharacter
+                    : formatValue(cellValue, {
                         //format date columns
-                        ...(granularity && column.dataType === 'time' ? {
-                          dateFormat: DATE_DISPLAY_FORMATS[granularity as keyof typeof DATE_DISPLAY_FORMATS]
-                        } : {}),
+                        ...(granularity && column.dataType === 'time'
+                          ? {
+                              dateFormat:
+                                theme.dateFormats[granularity as keyof typeof theme.dateFormats],
+                            }
+                          : {}),
                         //format measures
-                        ...(getMeasureByLabel(column.label) ? { meta: getMeasureByLabel(column.label)?.meta, type: 'number' } : {})
-                      })
-                  }
+                        ...(getMeasureByLabel(column.label)
+                          ? { meta: getMeasureByLabel(column.label)?.meta, type: 'number' }
+                          : {}),
+                      })}
                 </span>
               );
             }}
           />
-        )))
-      }
+        ))}
       </tbody>
     </table>
-  )
-}
+  );
+};
 
 export default PivotTable;

--- a/src/components/vanilla/charts/PivotTable/core/useTableColumns.ts
+++ b/src/components/vanilla/charts/PivotTable/core/useTableColumns.ts
@@ -4,11 +4,12 @@ import { Column } from './Column';
 import { ColumnType } from '../enums/ColumnType';
 import { createColumnKey } from '../utils/key';
 import formatValue from '../../../../util/format';
-import { DATE_DISPLAY_FORMATS } from '../../../../constants';
+import defaultTheme, { Theme } from '../../../../../defaulttheme';
+import { useOverrideConfig } from '@embeddable.com/react';
 
 type TableColumnHook = {
-  columns: Column[],
-  getLeafColumns: () => Column[]
+  columns: Column[];
+  getLeafColumns: () => Column[];
 };
 
 export const useTableColumns = (
@@ -18,36 +19,57 @@ export const useTableColumns = (
   columnDimensionValues: Record<string, string[]>,
   config: {
     aggregateRowDimensions?: boolean;
-    granularity?: string,
-  } = {}
+    granularity?: string;
+  } = {},
 ): TableColumnHook => {
-  function getRowDimensionColumns(aggregateRowDimensions: boolean = false, parent: Column | null = null): Column[] {
-    const rowDimensionCols = rowDimensions.map(rowDimension => new Column({
-      label: rowDimension.title,
-      key: rowDimension.name,
-      depth: columnDimensions.length,
-      type: ColumnType.ROW_HEADER,
-      dataType: rowDimension.nativeType,
-      parent
-    }));
+  // Get theme for use in component
+  const overrides: { theme: Theme } = useOverrideConfig() as { theme: Theme };
+  let { theme } = overrides;
+  if (!theme) {
+    theme = defaultTheme;
+  }
+  function getRowDimensionColumns(
+    aggregateRowDimensions: boolean = false,
+    parent: Column | null = null,
+  ): Column[] {
+    const rowDimensionCols = rowDimensions.map(
+      (rowDimension) =>
+        new Column({
+          label: rowDimension.title,
+          key: rowDimension.name,
+          depth: columnDimensions.length,
+          type: ColumnType.ROW_HEADER,
+          dataType: rowDimension.nativeType,
+          parent,
+        }),
+    );
 
     if (aggregateRowDimensions) {
-      return [new Column({
-        label: rowDimensions.map(rowDimension => rowDimension.title).join(' → '),
-        key: '__group.key',
-        depth: columnDimensions.length,
-        type: ColumnType.ROW_HEADER_GROUP,
-        group: rowDimensionCols,
-        parent
-      })]
+      return [
+        new Column({
+          label: rowDimensions.map((rowDimension) => rowDimension.title).join(' → '),
+          key: '__group.key',
+          depth: columnDimensions.length,
+          type: ColumnType.ROW_HEADER_GROUP,
+          group: rowDimensionCols,
+          parent,
+        }),
+      ];
     } else {
       return rowDimensionCols;
     }
   }
 
-  function createRowDimensionsColumn(columnDimensions: Dimension[], depth: number = 0, parent: Column | null = null): Column[] {
+  function createRowDimensionsColumn(
+    columnDimensions: Dimension[],
+    depth: number = 0,
+    parent: Column | null = null,
+  ): Column[] {
     if (!columnDimensions.length) {
-      return getRowDimensionColumns(config.aggregateRowDimensions && rowDimensions.length > 1, parent);
+      return getRowDimensionColumns(
+        config.aggregateRowDimensions && rowDimensions.length > 1,
+        parent,
+      );
     }
 
     const [currentColumnDimension, ...restColumnDimensions] = columnDimensions;
@@ -58,7 +80,7 @@ export const useTableColumns = (
       depth,
       type: ColumnType.DIMENSION,
       dataType: currentColumnDimension.nativeType,
-      parent
+      parent,
     });
 
     const children = createRowDimensionsColumn(restColumnDimensions, depth + 1, rowDimensionColumn);
@@ -67,51 +89,78 @@ export const useTableColumns = (
     return [rowDimensionColumn];
   }
 
-  function createMeasureColumns(columnDimensions: Dimension[], depth = 0, parent: Column | null = null, dimensionValuesInARow: string[] = []): Column[] {
+  function createMeasureColumns(
+    columnDimensions: Dimension[],
+    depth = 0,
+    parent: Column | null = null,
+    dimensionValuesInARow: string[] = [],
+  ): Column[] {
     if (!columnDimensions.length) {
-      return measures.map(measure => new Column({
-        label: measure.title,
-        key: createColumnKey([...dimensionValuesInARow, measure.name]),
-        depth,
-        type: ColumnType.MEASURE,
-        dataType: measure.nativeType,
-        parent: parent || null
-      }));
+      return measures.map(
+        (measure) =>
+          new Column({
+            label: measure.title,
+            key: createColumnKey([...dimensionValuesInARow, measure.name]),
+            depth,
+            type: ColumnType.MEASURE,
+            dataType: measure.nativeType,
+            parent: parent || null,
+          }),
+      );
     }
 
     const [currentColumnDimension, ...restColumnDimensions] = columnDimensions;
 
-    return columnDimensionValues[currentColumnDimension.name].map(dimensionValue => {
+    return columnDimensionValues[currentColumnDimension.name].map((dimensionValue) => {
       const column = new Column({
-        label: formatValue(dimensionValue, {
-          // type: currentColumnDimension.nativeType === 'time' ? 'date' : currentColumnDimension.nativeType as any,
-          ...(config.granularity && currentColumnDimension.nativeType === 'time' && dimensionValue ? {
-            dateFormat: DATE_DISPLAY_FORMATS[config.granularity as keyof typeof DATE_DISPLAY_FORMATS]
-          } : {})
-        }) ?? '-',
+        label:
+          formatValue(dimensionValue, {
+            // type: currentColumnDimension.nativeType === 'time' ? 'date' : currentColumnDimension.nativeType as any,
+            ...(config.granularity && currentColumnDimension.nativeType === 'time' && dimensionValue
+              ? {
+                  dateFormat:
+                    theme.dateFormats[config.granularity as keyof typeof theme.dateFormats],
+                }
+              : {}),
+          }) ?? '-',
         key: createColumnKey([...dimensionValuesInARow, dimensionValue]),
         depth,
         type: ColumnType.DIMENSION,
         dataType: currentColumnDimension.nativeType,
-        parent: parent
+        parent: parent,
       });
 
-      const children = createMeasureColumns(restColumnDimensions, depth + 1, column, [...dimensionValuesInARow, dimensionValue]);
+      const children = createMeasureColumns(restColumnDimensions, depth + 1, column, [
+        ...dimensionValuesInARow,
+        dimensionValue,
+      ]);
       column.addChildren(children);
 
       return column;
     });
   }
 
-  const columns: Column[] = useMemo(() => [
-    ...(rowDimensions.length ? createRowDimensionsColumn(columnDimensions) : []),
-    ...createMeasureColumns(columnDimensions)
-  ], [columnDimensions, rowDimensions, measures, columnDimensionValues, config.aggregateRowDimensions]);
+  const columns: Column[] = useMemo(
+    () => [
+      ...(rowDimensions.length ? createRowDimensionsColumn(columnDimensions) : []),
+      ...createMeasureColumns(columnDimensions),
+    ],
+    [
+      columnDimensions,
+      rowDimensions,
+      measures,
+      columnDimensionValues,
+      config.aggregateRowDimensions,
+    ],
+  );
 
-  const leafColumns: Column[] = useMemo(() => columns.map(column => column.getLeafColumns()).flat(), [columns]);
+  const leafColumns: Column[] = useMemo(
+    () => columns.map((column) => column.getLeafColumns()).flat(),
+    [columns],
+  );
 
   return {
     columns,
-    getLeafColumns: () => leafColumns
+    getLeafColumns: () => leafColumns,
   };
-}
+};


### PR DESCRIPTION
**Note: this is being merged to `develop` and not `main`**

This moves the pivot table away from constants and instead uses the new theming system.

This and similar PRs are going to be merged to dev without additional review, which will instead happen when all charts and controls are converted.