### PR TITLE
Grouped bar totals - fix for %s

### DIFF
--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -240,7 +240,7 @@ export default function getBarChartOptions({
               }
               return displayHorizontally ? 'right' : 'top';
             },
-            display: showTotals ? 'true' : false,
+            display: showTotals && stackBars ? 'true' : false,
             font: {
               weight: 'bold',
             },
@@ -254,7 +254,10 @@ export default function getBarChartOptions({
               const currxAxisName = xAxisNames[context.dataIndex];
               const currDatasetIndex = context.datasetIndex;
               if (currDatasetIndex === totals[currxAxisName].lastSegment && v !== null) {
-                let val = formatValue(totals[currxAxisName].total.toString(), {
+                const barTotal = displayAsPercentage
+                  ? '100'
+                  : totals[currxAxisName].total.toString();
+                let val = formatValue(barTotal, {
                   type: 'number',
                   dps: dps,
                   meta: displayAsPercentage ? undefined : metric?.meta,


### PR DESCRIPTION
Show '100' as the total when displayAsPercentage is true
Don't show the total at all if the bars are not stacked

**Issue**
The 'grouped bar chart' has a show as % option, and also has a 'show totals above bars' option. If both of these are true, the totals above the bars should always be "100", but currently it shows the sum of the original values (not the %s)

