### PR TITLE
Fix TPS-565 - Stacked Bar Chart Erroring w/ Undefined Data

### DIFF
--- a/src/components/util/getBarChartOptions.ts
+++ b/src/components/util/getBarChartOptions.ts
@@ -60,7 +60,7 @@ export default function getBarChartOptions({
   yAxisTitle = '',
   displayAsPercentage = false,
   isGroupedBar,
-  stackBars,  
+  stackBars,
 }: Partial<Props> & {
   lineMetrics?: Measure[];
   metric?: Measure;
@@ -76,7 +76,6 @@ export default function getBarChartOptions({
   isGroupedBar?: boolean;
   stackBars?: boolean;
 }): ChartOptions<'bar' | 'line'> {
-
   return {
     responsive: true,
     maintainAspectRatio: false,
@@ -91,11 +90,14 @@ export default function getBarChartOptions({
         grid: {
           display: false,
         },
-        max: (displayAsPercentage && !displayHorizontally) 
-          ? (isGroupedBar 
-              ? (stackBars ? 100 : undefined) 
-              : 100)
-          : undefined,
+        max:
+          displayAsPercentage && !displayHorizontally
+            ? isGroupedBar
+              ? stackBars
+                ? 100
+                : undefined
+              : 100
+            : undefined,
         afterDataLimits: function (axis) {
           //Disable fractions unless they exist in the data.
           const metricsGroup = [
@@ -148,11 +150,14 @@ export default function getBarChartOptions({
         grid: {
           display: false,
         },
-        max: displayAsPercentage && displayHorizontally 
-          ? (isGroupedBar 
-              ? stackBars ? 100 : undefined
-              : 100)
-          : undefined,
+        max:
+          displayAsPercentage && displayHorizontally
+            ? isGroupedBar
+              ? stackBars
+                ? 100
+                : undefined
+              : 100
+            : undefined,
         ticks: {
           //https://www.chartjs.org/docs/latest/axes/labelling.html
           callback: function (value) {
@@ -253,7 +258,7 @@ export default function getBarChartOptions({
               }
               const currxAxisName = xAxisNames[context.dataIndex];
               const currDatasetIndex = context.datasetIndex;
-              if (currDatasetIndex === totals[currxAxisName].lastSegment && v !== null) {
+              if (currDatasetIndex === totals[currxAxisName]?.lastSegment && v !== null) {
                 const barTotal = displayAsPercentage
                   ? '100'
                   : totals[currxAxisName].total.toString();


### PR DESCRIPTION
**Description**
The stacked bar chart was throwing an error in certain cases where an xAxis was being generated but had no data, and totals were set to display. This was causing issues for a client who had small amounts of data over a large time span, causing a lot of zero-data xAxis items to be generated (a bunch of dates w/ no data).

The fix for this is straightforward. Add an undefined check while putting together the data needed to display the totals.

**Acceptance Criteria**
- Code works (client verified this already, I asked them to make the change manually)
- Code looks good!