### PR TITLE
Fix checkbox sizing issue

### DIFF
--- a/src/components/icons/Checkbox.tsx
+++ b/src/components/icons/Checkbox.tsx
@@ -1,5 +1,12 @@
 const Checkbox: React.FC = () => (
-  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="shrink-0"
+  >
     <path
       d="M0 2.66667C0 1.19391 1.19391 0 2.66667 0H13.3333C14.8061 0 16 1.19391 16 2.66667V13.3333C16 14.8061 14.8061 16 13.3333 16H2.66667C1.19391 16 0 14.8061 0 13.3333V2.66667Z"
       fill="#333942"

--- a/src/components/icons/CheckboxEmpty.tsx
+++ b/src/components/icons/CheckboxEmpty.tsx
@@ -1,5 +1,12 @@
 const CheckboxEmpty: React.FC = () => (
-  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="shrink-0"
+  >
     <path
       d="M0.666667 2.66667C0.666667 1.5621 1.5621 0.666667 2.66667 0.666667H13.3333C14.4379 0.666667 15.3333 1.5621 15.3333 2.66667V13.3333C15.3333 14.4379 14.4379 15.3333 13.3333 15.3333H2.66667C1.5621 15.3333 0.666667 14.4379 0.666667 13.3333V2.66667Z"
       stroke="#959CA8"

--- a/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
+++ b/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
@@ -107,16 +107,14 @@ export default (props: Props) => {
               setTriggerBlur(false);
               set(o[props.property?.name || ''] || '');
             }}
-            className={`flex items-left min-h-[36px] px-3 py-2 hover:bg-black/5 cursor-pointer font-normal ${
+            className={`flex items-left items-center min-h-[36px] px-3 py-2 hover:bg-black/5 cursor-pointer font-normal ${
               value?.includes(o[props.property?.name || '']) ? 'bg-black/5' : ''
             } whitespace-nowrap overflow-hidden text-ellipsis`}
           >
             <div style={{ width: '16px', display: 'inline-block' }}>
               {value?.includes(o[props.property?.name || '']) ? <Checkbox /> : <CheckboxEmpty />}
             </div>
-            <span className="font-normal pl-1 text-xs opacity-70">
-              {o[props.property?.name || '']}
-            </span>
+            <span className="font-normal pl-1">{o[props.property?.name || '']}</span>
             {o.note && <span className="font-normal pl-3 text-xs opacity-70">{o.note}</span>}
           </div>,
         );

--- a/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
+++ b/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
@@ -107,15 +107,17 @@ export default (props: Props) => {
               setTriggerBlur(false);
               set(o[props.property?.name || ''] || '');
             }}
-            className={`flex items-center min-h-[36px] px-3 py-2 hover:bg-black/5 cursor-pointer font-normal gap-1 ${
+            className={`flex items-left min-h-[36px] px-3 py-2 hover:bg-black/5 cursor-pointer font-normal ${
               value?.includes(o[props.property?.name || '']) ? 'bg-black/5' : ''
             } whitespace-nowrap overflow-hidden text-ellipsis`}
           >
-            {value?.includes(o[props.property?.name || '']) ? <Checkbox /> : <CheckboxEmpty />}
-            {o[props.property?.name || '']}
-            {o.note && (
-              <span className="font-normal ml-auto pl-3 text-xs opacity-70">{o.note}</span>
-            )}
+            <div style={{ width: '16px', display: 'inline-block' }}>
+              {value?.includes(o[props.property?.name || '']) ? <Checkbox /> : <CheckboxEmpty />}
+            </div>
+            <span className="font-normal pl-1 text-xs opacity-70">
+              {o[props.property?.name || '']}
+            </span>
+            {o.note && <span className="font-normal pl-3 text-xs opacity-70">{o.note}</span>}
           </div>,
         );
 

--- a/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
+++ b/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
@@ -109,10 +109,12 @@ export default (props: Props) => {
             }}
             className={`flex items-left items-center min-h-[36px] px-3 py-2 hover:bg-black/5 cursor-pointer font-normal ${
               value?.includes(o[props.property?.name || '']) ? 'bg-black/5' : ''
-            } whitespace-nowrap overflow-hidden text-ellipsis`}
+            } truncate`}
           >
             {value?.includes(o[props.property?.name || '']) ? <Checkbox /> : <CheckboxEmpty />}
-            <span className="font-normal pl-1">{o[props.property?.name || '']}</span>
+            <span className="font-normal pl-1 truncate" title={o[props.property?.name || '']}>
+              {o[props.property?.name || '']}
+            </span>
             {o.note && <span className="font-normal pl-3 text-xs opacity-70">{o.note}</span>}
           </div>,
         );

--- a/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
+++ b/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
@@ -111,9 +111,7 @@ export default (props: Props) => {
               value?.includes(o[props.property?.name || '']) ? 'bg-black/5' : ''
             } whitespace-nowrap overflow-hidden text-ellipsis`}
           >
-            <div style={{ width: '16px', display: 'inline-block' }}>
-              {value?.includes(o[props.property?.name || '']) ? <Checkbox /> : <CheckboxEmpty />}
-            </div>
+            {value?.includes(o[props.property?.name || '']) ? <Checkbox /> : <CheckboxEmpty />}
             <span className="font-normal pl-1">{o[props.property?.name || '']}</span>
             {o.note && <span className="font-normal pl-3 text-xs opacity-70">{o.note}</span>}
           </div>,


### PR DESCRIPTION
## Description

In multi-select dropdowns where the text is very long (or the dropdown size very small), the dropdown resizes the checkboxes making them either tiny (and hard to click) or nonexistent (and impossible to click). Ensure that it gives preference to the checkbox and always keeps it the same size, and overflows the text instead.

## Acceptance Criteria
- All checkboxes are always the same size and always visible.

## Screenshots

**Before**
<img width="120" alt="image" src="https://github.com/user-attachments/assets/3f69d456-51c3-4fc1-bbdb-f1f9b1feda50" />
**After**
<img width="115" alt="image" src="https://github.com/user-attachments/assets/7d515374-2195-49a6-b4ba-34954c43571f" />
