### PR TITLE
Allow for overriding individual chart colors

### DIFF
--- a/src/components/util/chartjs/common.ts
+++ b/src/components/util/chartjs/common.ts
@@ -29,9 +29,7 @@ export const setChartJSDefaults = (theme: Theme, chartType?: ChartType) => {
   // remove 'px' from the font size and convert to a number
   let fontSize = parseInt(theme.font.size.replace('px', ''), 10);
   if (chartType && theme.charts[chartType]) {
-    if (theme.charts[chartType].font?.size) {
-      fontSize = theme.charts[chartType].font.size;
-    }
+    fontSize = theme.charts[chartType].font.size;
   }
   // We don't need to return Chartjs defaults as we are mutating the global object
   ChartJS.defaults.font.size = fontSize;

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -75,6 +75,12 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
   } = theme;
   setChartJSDefaults(theme);
 
+  // Check for bar chart color overrides in theme
+  let chartColors = colors;
+  if (theme.charts.bar.colors) {
+    chartColors = theme.charts.bar.colors;
+  }
+
   let dateFormat: string | undefined;
   if (xAxis.nativeType === 'time' && granularity) {
     dateFormat = dateFormats[granularity];
@@ -94,7 +100,7 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
 
   const metricsDatasets =
     metrics?.map((metric, i) => ({
-      backgroundColor: colors[i % colors.length],
+      backgroundColor: chartColors[i % chartColors.length],
       barPercentage: 0.8,
       barThickness: 'flex',
       borderRadius: theme.charts.bar.borderRadius,
@@ -110,8 +116,8 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
   //optional metrics to display as a line on the barchart
   const lineMetricsDatasets =
     lineMetrics?.map((metric, i) => ({
-      backgroundColor: colors[metrics.length + (i % colors.length)],
-      borderColor: colors[metrics.length + (i % colors.length)],
+      backgroundColor: chartColors[metrics.length + (i % chartColors.length)],
+      borderColor: chartColors[metrics.length + (i % chartColors.length)],
       cubicInterpolationMode: 'monotone' as const,
       data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
       label: metric.title,

--- a/src/components/vanilla/charts/BubbleChart/index.tsx
+++ b/src/components/vanilla/charts/BubbleChart/index.tsx
@@ -63,6 +63,12 @@ type Record = { [p: string]: any };
 export default (props: Props) => {
   const theme: Theme = useTheme() as Theme;
 
+  // Check for chart-specific overrides in the theme
+  let chartColors = theme.charts.colors;
+  if (theme.charts.bubble.colors) {
+    chartColors = theme.charts.bubble.colors;
+  }
+
   //add missing dates to time-series data
   const { fillGaps } = useTimeseries(props, 'desc');
   const { results } = props;
@@ -73,7 +79,7 @@ export default (props: Props) => {
     ...props,
     theme: theme,
   };
-  const bubbleData = chartData(updatedProps, updatedData);
+  const bubbleData = chartData(updatedProps, updatedData, chartColors);
 
   return (
     <Container {...props} className="overflow-y-hidden">
@@ -226,6 +232,7 @@ function chartOptions(
 function chartData(
   props: PropsWithRequiredTheme,
   updatedData: Record[] | undefined,
+  chartColors: string[],
 ): ChartData<'bubble'> {
   const { theme } = props;
   const bubbleRadiusValue =
@@ -251,7 +258,7 @@ function chartData(
       {
         label: props.yAxis.title,
         data: ndata,
-        backgroundColor: hexToRgb(theme.charts.colors[0], 0.8),
+        backgroundColor: hexToRgb(chartColors[0], 0.8),
       },
     ],
   };

--- a/src/components/vanilla/charts/LineChart/index.tsx
+++ b/src/components/vanilla/charts/LineChart/index.tsx
@@ -80,6 +80,12 @@ export default (props: Props) => {
 
     const data = results?.data?.reduce(fillGaps, []);
 
+    // Check for color overrides in the theme
+    let chartColors = theme.charts.colors;
+    if (theme.charts.line.colors) {
+      chartColors = theme.charts.line.colors;
+    }
+
     return {
       datasets:
         metrics?.map((yAxis, i) => ({
@@ -90,9 +96,9 @@ export default (props: Props) => {
               x: parseTime(d[props.xAxis?.name || '']),
             })) || [],
           backgroundColor: applyFill
-            ? hexToRgb(theme.charts.colors[i % theme.charts.colors.length], 0.2)
-            : theme.charts.colors[i % theme.charts.colors.length],
-          borderColor: theme.charts.colors[i % theme.charts.colors.length],
+            ? hexToRgb(chartColors[i % chartColors.length], 0.2)
+            : chartColors[i % chartColors.length],
+          borderColor: chartColors[i % chartColors.length],
           pointRadius: 0,
           tension: theme.charts.line.lineTension,
           pointHoverRadius: 3,

--- a/src/components/vanilla/charts/PieChart/index.tsx
+++ b/src/components/vanilla/charts/PieChart/index.tsx
@@ -59,6 +59,12 @@ export default (props: Props) => {
   // Set ChartJS defaults
   setChartJSDefaults(theme, 'pie');
 
+  // Check for color overrides in the theme
+  let chartColors = theme.charts.colors;
+  if (theme.charts.pie.colors) {
+    chartColors = theme.charts.pie.colors;
+  }
+
   // Add the theme to props
   const updatedProps: PropsWithRequiredTheme = {
     ...props,
@@ -103,7 +109,7 @@ export default (props: Props) => {
       <Pie
         height="100%"
         options={chartOptions(updatedProps)}
-        data={chartData(updatedProps)}
+        data={chartData(updatedProps, chartColors)}
         ref={chartRef}
         onClick={handleClick}
       />
@@ -185,7 +191,7 @@ function mergeLongTail({ results, slice, metric, maxSegments }: Props) {
   return newData;
 }
 
-function chartData(props: PropsWithRequiredTheme) {
+function chartData(props: PropsWithRequiredTheme, chartColors: string[]) {
   const { maxSegments, results, metric, slice, displayAsPercentage, theme } = props;
   const labelsExceedMaxSegments = maxSegments && maxSegments < (results?.data?.length || 0);
   const newData = labelsExceedMaxSegments ? mergeLongTail(props) : results.data;
@@ -208,7 +214,7 @@ function chartData(props: PropsWithRequiredTheme) {
     datasets: [
       {
         data: counts,
-        backgroundColor: theme.charts.colors,
+        backgroundColor: chartColors,
         borderColor: '#fff',
         borderWeight: 5,
       },

--- a/src/themes/defaulttheme.ts
+++ b/src/themes/defaulttheme.ts
@@ -29,6 +29,9 @@ export const defaultTheme: Theme = {
     bar: {
       borderRadius: 4,
       borderWidth: 0,
+      font: {
+        size: 12,
+      },
     },
     bubble: {
       font: {
@@ -49,6 +52,11 @@ export const defaultTheme: Theme = {
       lineTension: 0.1,
     },
     pie: {
+      font: {
+        size: 12,
+      },
+    },
+    scatter: {
       font: {
         size: 12,
       },

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -1,15 +1,4 @@
-export type ChartType =
-  | 'bar'
-  | 'bubble'
-  | 'doughnut'
-  | 'kpi'
-  | 'line'
-  | 'pie'
-  | 'pivotTable'
-  | 'polarArea'
-  | 'radar'
-  | 'scatter'
-  | 'table';
+export type ChartType = 'bar' | 'bubble' | 'kpi' | 'line' | 'pie' | 'scatter';
 
 type ButtonSettings = {
   background: string;
@@ -32,26 +21,40 @@ export type Theme = {
     bar: {
       borderRadius: number;
       borderWidth: number;
+      colors?: string[];
+      font: {
+        size: number;
+      };
     };
     bubble: {
+      colors?: string[];
       font: {
         size: number;
       };
     };
     kpi: {
       alignment: string;
+      colors?: string[];
       font: {
         negativeColor: string;
         size: number;
       };
     };
     line: {
+      colors?: string[];
       font: {
         size: number;
       };
       lineTension: number;
     };
     pie: {
+      colors?: string[];
+      font: {
+        size: number;
+      };
+    };
+    scatter: {
+      colors?: string[];
       font: {
         size: number;
       };


### PR DESCRIPTION
Allows theme control of chart colors on a per-chart-type basis. eg: bar chart and pie chart can have different colors. If no value is set, defaults to the standard colors.