### PR TITLE
Dynamic Axis Barchart fix

### DIFF
--- a/src/components/vanilla/charts/DynamicAxisBar/index.tsx
+++ b/src/components/vanilla/charts/DynamicAxisBar/index.tsx
@@ -65,7 +65,7 @@ export default (props: Props) => {
         </div>
       </div>
       <div className="flex grow overflow-hidden">
-        {results.isLoading || !xAxis || results?.data?.[0]?.[xAxis.name] == null ? null : (
+        {results.isLoading || !xAxis || !results?.data?.filter((_,i) => i < 10)?.some((row) => row[xAxis.name]) ? null : (
           <BarChart key={value} {...updatedProps} />
         )}
       </div>


### PR DESCRIPTION
In dynamic axis chart, check that any of the first 10 results contain the updated xAxis value, not just the first row (which might be null)