### PR TITLE
Fix TPS-676 - Table Component Not Updating Results

### DIFF
--- a/src/components/vanilla/charts/TableChart/TableChart.emb.ts
+++ b/src/components/vanilla/charts/TableChart/TableChart.emb.ts
@@ -116,7 +116,7 @@ export default defineComponent<
     const limit =
       inputs.maxPageRows || state?.maxRowsFit
         ? Math.min(inputs.maxPageRows || 1000, Math.max(state?.maxRowsFit, 1) || 1000)
-        : 1;
+        : 0;
 
     const defaultSortDirection =
       // @ts-expect-error - defaultSortDirection.value is added by defineComponent.
@@ -147,14 +147,19 @@ export default defineComponent<
       ...inputs,
       limit,
       defaultSort,
-      results: loadData({
-        from: inputs.ds,
-        dimensions: (inputs.columns?.filter((c) => isDimension(c)) as Dimension[]) || [],
-        measures: (inputs.columns?.filter((c) => isMeasure(c)) as Measure[]) || [],
-        limit,
-        offset: limit * (state?.page || 0),
-        orderBy: state?.sort || defaultSort,
-      }),
+      results:
+        limit < 1
+          ? {
+              isLoading: true,
+            }
+          : loadData({
+              from: inputs.ds,
+              dimensions: (inputs.columns?.filter((c) => isDimension(c)) as Dimension[]) || [],
+              measures: (inputs.columns?.filter((c) => isMeasure(c)) as Measure[]) || [],
+              limit,
+              offset: limit * (state?.page || 0),
+              orderBy: state?.sort || defaultSort,
+            }),
     };
   },
 });

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -31,8 +31,6 @@ export default (props: Props) => {
   const [maxRowsFit, setMaxRowFit] = useState(0);
   const [resizing, setResizing] = useState(false);
 
-  console.log('maxRowsFit', maxRowsFit);
-
   const [meta, setMeta] = useEmbeddableState({
     page: 0,
     maxRowsFit: 0,

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -31,6 +31,8 @@ export default (props: Props) => {
   const [maxRowsFit, setMaxRowFit] = useState(0);
   const [resizing, setResizing] = useState(false);
 
+  console.log('maxRowsFit', maxRowsFit);
+
   const [meta, setMeta] = useEmbeddableState({
     page: 0,
     maxRowsFit: 0,


### PR DESCRIPTION
**Description**
The table component was double-loading data and encountering a race condition that caused it to sometimes only load one row of data, and sometimes load the actual correct amount. This was only occurring when filters were set while editing the table, because this action reset Embeddable State (unlike, say, resizing), causing it to return `maxRowSize` to a default of `0` briefly before then recalculating and updating that value.

**Solution**
Adjusted table `loadData` call to only finish loading when either the max rows are manually set, or the table's height has finished calculating and is returned by `useEmbeddableState`.

**Acceptance Criteria**
- [x] Table performs the same as it did before
- [x] Table no longer has a bug where it sometimes doesn't correctly display data in the builder if the filters are changed 