### PR TITLE
TPS-618 - Download Button Doesn't Always Respond to Filters

### DIFF
--- a/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
+++ b/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
@@ -60,7 +60,7 @@ export const meta = {
 
 export default defineComponent<Props, typeof meta, { downloading: boolean }>(Component, meta, {
   props: (inputs: Inputs<typeof meta>, [state]) => {
-    const downloading = state?.downloading === false;
+    const downloading = state?.downloading === true;
     let results = {
       isLoading: false,
     };


### PR DESCRIPTION
**Description**
We've had numerous reports from clients that the download button doesn't always behave as expected, giving truncated or otherwise incorrect data. After investigation, I found that only the first click of the download button was correctly giving data - after that it was fighting race conditions and often initiating a download on the previous data before the new data had finished loading.

**Solution**
I introduced a new state value that contains the last-downloaded data. We then compare the data that the button is attempting to download with the last-downloaded data and, if they're the same, we wait until the new `loadData` has finished before firing the download (and replacing the last-downloaded data state). This works consistently and should solve the issues with the download button but does introduce some memory usage concerns for large datasets.

I attempted to get around this by storing a timestamp rather than the data itself, but unfortunately the new timestamp can't be added to the `loadData` results (it gets stripped by the SDK), and if we return it in the object that contains the results, then it updates too quickly and runs into the same race conditions mentioned above. Basically: we see the new timestamp before the `loadData` has finished and end up still downloading the old data.

The current solution works reliably and only ever stores one dataset, so I don't think memory usage is likely to be a huge issue, but it's worth monitoring and if customers are having issues, we may need to make some SDK adjustments to allow the timestamp approach to work.

**Acceptance Criteria**
 - [x] Download Button reliably downloads the latest data on each click
 - [x] Download Button reliably matches up with filters on the dataset enacted either at the builder level or via variables (eg setting a time span with the datepicker)
 - [ ] Code looks good 🙂