### PR TITLE
CS-16 - Add Download All as CSV button to Table component

### DIFF
--- a/src/components/vanilla/Container.tsx
+++ b/src/components/vanilla/Container.tsx
@@ -15,6 +15,7 @@ export type ContainerProps = {
   childContainerClassName?: string;
   className?: string;
   description?: string;
+  downloadAllFunction?: () => void;
   enableDownloadAsCSV?: boolean;
   enableDownloadAsPNG?: boolean;
   onResize?: (size: Size) => void;
@@ -126,6 +127,7 @@ export default ({
               prevResults: props.prevResults,
             },
           }}
+          downloadAllFunction={props.downloadAllFunction}
           enableDownloadAsCSV={props.enableDownloadAsCSV}
           enableDownloadAsPNG={props.enableDownloadAsPNG}
           pngOpts={{ chartName: props.title || 'chart', element: refExportPNGElement.current }}

--- a/src/components/vanilla/DownloadMenu.tsx
+++ b/src/components/vanilla/DownloadMenu.tsx
@@ -113,7 +113,8 @@ const DownloadMenu: React.FC<Props> = (props) => {
   }
 
   // If only CSV is enabled, skip the menu and show just the CSV download Icon
-  if (enableDownloadAsCSV && !enableDownloadAsPNG) {
+  // If there's a downloadAllFunction, we need to show the menu
+  if (enableDownloadAsCSV && !enableDownloadAsPNG && !downloadAllFunction) {
     return (
       <div className="absolute top-0 right-0 z-5 flex items-center justify-end space-x-2">
         <div onClick={handleCSVClick} className="cursor-pointer">

--- a/src/components/vanilla/DownloadMenu.tsx
+++ b/src/components/vanilla/DownloadMenu.tsx
@@ -18,6 +18,7 @@ type Props = {
     chartName: string;
     props: CSVProps;
   };
+  downloadAllFunction?: () => void;
   enableDownloadAsCSV?: boolean;
   enableDownloadAsPNG?: boolean;
   pngOpts?: {
@@ -31,6 +32,7 @@ type Props = {
 const DownloadMenu: React.FC<Props> = (props) => {
   const {
     csvOpts,
+    downloadAllFunction,
     enableDownloadAsCSV,
     enableDownloadAsPNG,
     pngOpts,
@@ -146,7 +148,7 @@ const DownloadMenu: React.FC<Props> = (props) => {
           )}
           {showMenu && (
             <>
-              <div className="absolute bg-white flex items-center right-0 p-4 rounded shadow-md top-6 w-40 whitespace-nowrap">
+              <div className="absolute bg-white flex items-center right-0 p-4 rounded shadow-md top-6 max-w-100 whitespace-nowrap">
                 <ul>
                   <li className="mb-2">
                     <a
@@ -157,6 +159,18 @@ const DownloadMenu: React.FC<Props> = (props) => {
                       <IconDownloadCSV className="cursor-pointer inline-block mr-2" /> Download CSV
                     </a>
                   </li>
+                  {downloadAllFunction && (
+                    <li className="mb-2">
+                      <a
+                        href="#"
+                        onClick={downloadAllFunction}
+                        className="inline-block flex items-center hover:opacity-100 opacity-60"
+                      >
+                        <IconDownloadCSV className="cursor-pointer inline-block mr-2" /> Download
+                        All as CSV
+                      </a>
+                    </li>
+                  )}
                   <li>
                     <a
                       href="#"

--- a/src/components/vanilla/charts/TableChart/TableChart.emb.ts
+++ b/src/components/vanilla/charts/TableChart/TableChart.emb.ts
@@ -167,7 +167,7 @@ export default defineComponent<
       from: inputs.ds,
       dimensions: (inputs.columns?.filter((c) => isDimension(c)) as Dimension[]) || [],
       measures: (inputs.columns?.filter((c) => isMeasure(c)) as Measure[]) || [],
-      limit: state?.downloadAll ? 50000 : 0,
+      limit: state?.downloadAll ? 10_000 : 0,
       offset: 0,
       orderBy: state?.sort || defaultSort,
     });


### PR DESCRIPTION
**Description**
We have a lot of clients who don't love that the "download as CSV" option on the table only downloads one page of data. Rather than grabbing the entire dataset every single time and doing paging specifically on the front-end, I added a solution that does a second `loadData` but with a zero limit, unless a certain state value is `true`. This allows us to only load the full dataset when it's actually being requested, and in addition prevents issues with props "caching" (to be investigated by engineering at a later date).

**Acceptance Criteria**
- [x] Download All button exists
- [x] Download All button downloads all data from the dataset
- [x] Download All button responds correctly to dataset filters
- [x] Full dataset is only loaded when download button is clicked
- [x] Download Menu can take an optional `downloadAllFunction` prop that enables the menu item  