### PR TITLE
CS-66 - Dropdowns Not Recognizing Second Click

### DIFF
--- a/src/components/vanilla/controls/Dropdown/index.tsx
+++ b/src/components/vanilla/controls/Dropdown/index.tsx
@@ -130,7 +130,6 @@ export default (props: Props) => {
             setFocus(true);
             setTriggerBlur(false);
           }}
-          onFocus={() => setFocus(true)}
           onBlur={() => setTriggerBlur(true)}
           onChange={(e) => performSearch(e.target.value)}
           className={`outline-none bg-transparent leading-9 h-9 border-0 px-3 w-full cursor-pointer text-sm ${

--- a/src/components/vanilla/controls/Dropdown/index.tsx
+++ b/src/components/vanilla/controls/Dropdown/index.tsx
@@ -94,7 +94,7 @@ export default (props: Props) => {
             key={i}
             onClick={() => {
               setFocus(false);
-              setTriggerBlur(false);
+              setTriggerBlur(true);
               set(o[props.property?.name || ''] || '');
             }}
             className={`flex items-center min-h-[36px] px-3 py-2 hover:bg-black/5 cursor-pointer font-normal ${
@@ -126,6 +126,10 @@ export default (props: Props) => {
           value={search}
           name="dropdown"
           placeholder={props.placeholder}
+          onClick={() => {
+            setFocus(true);
+            setTriggerBlur(false);
+          }}
           onFocus={() => setFocus(true)}
           onBlur={() => setTriggerBlur(true)}
           onChange={(e) => performSearch(e.target.value)}


### PR DESCRIPTION
** Description **

Due to the fix for the scrollbar issue on dropdowns (where dragging the scrollbar would cause a `blur` and the window would shut while you were dragging), once you selected an option, you could not open the dropdown again unless you clicked somewhere else on the page. This was annoying and confusing. It's now fixed.

** Acceptance Criteria **
 - [x] Dropdown opens with subsequent clicks without the need to click elsewhere on the page
 - [x] Dragging the scrollbar is still fixed 