### PR TITLE
TPS-709 - Download All Button Is an Un-default-prevented Link

### DIFF
--- a/src/components/vanilla/DownloadMenu.tsx
+++ b/src/components/vanilla/DownloadMenu.tsx
@@ -164,7 +164,10 @@ const DownloadMenu: React.FC<Props> = (props) => {
                     <li className="mb-2">
                       <a
                         href="#"
-                        onClick={downloadAllFunction}
+                        onClick={(e: React.MouseEvent) => {
+                          e.preventDefault();
+                          downloadAllFunction();
+                        }}
                         className="inline-block flex items-center hover:opacity-100 opacity-60"
                       >
                         <IconDownloadCSV className="cursor-pointer inline-block mr-2" /> Download


### PR DESCRIPTION
**Description**

The download all selection in the download menu, being a link, needs to be default prevented in order to avoid strange behavior when embedded in the client repo.

**Acceptance Criteria**

 - [x] Download All Button is default-prevented
