### PR TITLE
CS-67 - Line Chart Axis

### DIFF
--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -28,6 +28,16 @@ export const meta = {
       category: 'Chart data',
     },
     {
+      name: 'comparisonXAxis',
+      type: 'dimension',
+      label: 'Comparison X-Axis (optional)',
+      config: {
+        dataset: 'ds',
+        supportedTypes: ['time'],
+      },
+      category: 'Chart data',
+    },
+    {
       name: 'metrics',
       type: 'measure',
       array: true,
@@ -77,6 +87,14 @@ export const meta = {
       type: 'string',
       label: 'X-Axis Title',
       category: 'Chart settings',
+    },
+    {
+      name: 'comparisonXAxisTitle',
+      type: 'string',
+      label: 'Comparison X-Axis Title (optional)',
+      description: 'Title for the comparison X-Axis',
+      category: 'Chart settings',
+      defaultValue: '',
     },
     {
       name: 'yAxisTitle',
@@ -154,6 +172,14 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          ...(inputs.comparisonXAxis
+            ? [
+                {
+                  dimension: inputs.comparisonXAxis.name,
+                  granularity: inputs.granularity,
+                },
+              ]
+            : []),
         ],
         measures: inputs.metrics,
         filters:

--- a/src/components/vanilla/charts/CompareLineChart/index.tsx
+++ b/src/components/vanilla/charts/CompareLineChart/index.tsx
@@ -63,12 +63,14 @@ type Props = {
   title?: string;
   ds: Dataset;
   xAxis: Dimension;
+  comparisonXAxis?: Dimension;
   granularity: Granularity;
   metrics: Measure[];
   timeFilter?: TimeRange;
   prevTimeFilter?: TimeRange;
   yAxisMin?: number;
   xAxisTitle?: string;
+  comparisonXAxisTitle?: string;
   yAxisTitle?: string;
   applyFill?: boolean;
   showLabels?: boolean;
@@ -128,7 +130,7 @@ export default (propsInitial: Props) => {
           data: props.prevTimeFilter
             ? prevData?.map((d: Record) => ({
                 y: parseFloat(d[metrics[i].name] || '0'),
-                x: parseTime(d[props.xAxis?.name || '']),
+                x: parseTime(d[props.comparisonXAxis?.name || '']),
               })) || []
             : [],
           backgroundColor: applyFill ? hexToRgb(COLORS[i % COLORS.length], 0.05) : c,
@@ -184,14 +186,11 @@ export default (propsInitial: Props) => {
             text: props.yAxisTitle,
           },
           callback: function (value: number) {
-            return formatValue(
-              value.toString(), 
-              { type: 'number' }
-            )
+            return formatValue(value.toString(), { type: 'number' });
           },
-          afterDataLimits: function(axis) {
+          afterDataLimits: function (axis) {
             //Disable fractions unless they exist in the data.
-            setYAxisStepSize(axis, props.results, [...props.metrics], props.dps)
+            setYAxisStepSize(axis, props.results, [...props.metrics], props.dps);
           },
         },
         period: {
@@ -215,7 +214,7 @@ export default (propsInitial: Props) => {
         comparison: {
           min: bounds.comparison?.from?.toJSON(),
           max: bounds.comparison?.to?.toJSON(),
-          display: false,
+          display: !!props.comparisonXAxis,
           grid: {
             display: false,
           },
@@ -227,7 +226,8 @@ export default (propsInitial: Props) => {
             unit: props.granularity,
           },
           title: {
-            display: false,
+            display: !!props.comparisonXAxisTitle,
+            text: props.comparisonXAxisTitle,
           },
         },
       },
@@ -267,14 +267,16 @@ export default (propsInitial: Props) => {
           align: 'top',
           display: props.showLabels ? 'auto' : false,
           formatter: (v, context) => {
-            //get metrics index including for comparison datasets 
+            //get metrics index including for comparison datasets
             const metricIndex = context.datasetIndex % props.metrics.length;
             const metric = props.metrics[metricIndex];
-            const val = v ? formatValue(v.y, { 
-                type: 'number', 
-                dps: props.dps,
-                meta: metric?.meta
-            }) : null;
+            const val = v
+              ? formatValue(v.y, {
+                  type: 'number',
+                  dps: props.dps,
+                  meta: metric?.meta,
+                })
+              : null;
             return val;
           },
         },


### PR DESCRIPTION
**Description**
Adds a second, optional x-axis to the Comparison Line Chart so that users can see the dates for both the period and comparison values.

**Acceptance Criteria**
 - [x] Users can add a second x-axis and have it display accurately in conjunction with the comparison data
 - [x] Users can give the second x-axis a title if they want to
 - [x] Chart behaves as expected with second x-axis
 - [x] Chart behaves as expected _without_ second x-axis