### PR TITLE
Fix - Comparison Line

### DIFF
--- a/src/components/vanilla/charts/CompareLineChart/index.tsx
+++ b/src/components/vanilla/charts/CompareLineChart/index.tsx
@@ -130,7 +130,7 @@ export default (propsInitial: Props) => {
           data: props.prevTimeFilter
             ? prevData?.map((d: Record) => ({
                 y: parseFloat(d[metrics[i].name] || '0'),
-                x: parseTime(d[props.comparisonXAxis?.name || '']),
+                x: parseTime(d[props.comparisonXAxis?.name || props.xAxis.name || '']),
               })) || []
             : [],
           backgroundColor: applyFill ? hexToRgb(COLORS[i % COLORS.length], 0.05) : c,


### PR DESCRIPTION
Fixes bug where comparison line chart crashes if secondary xAxis title isn't given. This fix is already tested and working in VC v1 (and also by one of our clients using VC v0, which is how I confirmed I'd missed it in this repo!).