### PR TITLE
CS-27 - Support Markdown in Table Links

### DIFF
--- a/src/components/util/format.ts
+++ b/src/components/util/format.ts
@@ -50,3 +50,11 @@ export default function formatValue(str: string = '', opt: Type | Options = 'str
     return `${meta?.pretext || ''}${v}${meta?.posttext || ''}`;
   }
 }
+
+export const detectAndReturnLinks = (text: string) => {
+  if (!text) {
+    return { linkText: null, linkUrl: null };
+  }
+  const linkData = /\[(.*)\]\((.*)\)/.exec(text);
+  return { linkText: linkData?.[1], linkUrl: encodeURI(linkData?.[2] || '') };
+};


### PR DESCRIPTION
**Description**

Checks all table column values to see if any of them are markdown formatted links. If so, it returns an anchor dom element with the appropriate text/href, rather than just plain text.

I went ahead and left the sample link measure in the model file, as it may be useful for us down the line when testing other things

**Acceptance Criteria**
 
 - [x] Works
 - [x] Code makes sense 

**Screenshot**

Browser showing that the text is an active link (see bottom left corner)

<img width="1294" height="304" alt="image" src="https://github.com/user-attachments/assets/2b028be0-9ece-4c18-9608-7e00f4a158e5" />
