### PR TITLE
Fix - Bar Chart Granularity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,10 +38,10 @@
         "vite-plugin-css-injected-by-js": "^3.1.1"
       },
       "devDependencies": {
-        "@embeddable.com/core": "^2.10.5",
-        "@embeddable.com/react": "^2.10.6",
-        "@embeddable.com/sdk-core": "^4.0.0",
-        "@embeddable.com/sdk-react": "^4.0.0",
+        "@embeddable.com/core": "^2.10.7",
+        "@embeddable.com/react": "^2.10.8",
+        "@embeddable.com/sdk-core": "^4.0.2",
+        "@embeddable.com/sdk-react": "^4.0.2",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/d3-scale": "^4.0.8",
         "@types/leaflet": "^1.9.14",
@@ -787,9 +787,9 @@
       }
     },
     "node_modules/@embeddable.com/core": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/core/-/core-2.10.5.tgz",
-      "integrity": "sha512-hZEIZ7KImtRXjPX/Rj1a0z9i03zNelT0ZZ49Feh8TdliL3OSNt4GMgX++qDWey9bEZ/db0fNYfKxoNyNaRwxhw==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/core/-/core-2.10.7.tgz",
+      "integrity": "sha512-OLYzmheCnOR8JKjvau5c//4Unx7rAVPn9AtTPEyR9tma7g+5TSH3xHuiWTou6NOLhtAT2es3P62LuncpC1SQNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -798,27 +798,27 @@
       }
     },
     "node_modules/@embeddable.com/react": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.10.6.tgz",
-      "integrity": "sha512-Q/s0+d0tHY+XDuDwVwuTxtWQdIgRfnGVXVDCx0WzGnJhFPQwsM5BDFZri/YNXn4SZg6jEx/3uRLeitwWQwgxHA==",
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.10.8.tgz",
+      "integrity": "sha512-pECZCWOiOX6iHOyXr+3y1y06XXZBf8Sup7c2Z57b9X7bQiOj+Xr0M3OTpzSo1FHnqCJ+IUIJd2Pdr7cf966C4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@embeddable.com/core": "2.10.5"
+        "@embeddable.com/core": "2.10.7"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@embeddable.com/sdk-core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.0.0.tgz",
-      "integrity": "sha512-DgpYXrtMnhNRvLuee8o1numxKLOkeM8NgqJafokH2C2oYIYnYxU+7i58AoW1qakLn0C+ZkaDB92TU+ssPpQulw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.0.2.tgz",
+      "integrity": "sha512-Ia14etRgT+qRznCaQqODMYA47nPus8X4l05RjDGVbms4i/8+qKhJ5ibBL6pxeXfG7Mk4vBKKy3z6UiNXoWiIcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@embeddable.com/core": "2.10.5",
-        "@embeddable.com/sdk-utils": "0.8.1",
+        "@embeddable.com/core": "2.10.7",
+        "@embeddable.com/sdk-utils": "0.8.2",
         "@inquirer/prompts": "^7.2.1",
         "@stencil/core": "^4.23.0",
         "@swc-node/register": "^1.10.9",
@@ -949,17 +949,17 @@
       }
     },
     "node_modules/@embeddable.com/sdk-react": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.0.0.tgz",
-      "integrity": "sha512-Z2orcyvPTTU0bkk9DhRpPl87Nxq4Ed5GnHzaHbGykb+2zosH3qne2aocHcRf91uiJmeyvO4+o6uooJ7mblgH7Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.0.2.tgz",
+      "integrity": "sha512-CmECyYRTEtvEcstv21kdJC+66yemQwa18qZc3pz0k3TvHWNEwnOWuObinVNFSiFixRejrDsVxxuntXqsaifn7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.23.0",
         "@babel/parser": "^7.26.2",
         "@babel/traverse": "^7.24.7",
-        "@embeddable.com/sdk-core": "4.0.0",
-        "@embeddable.com/sdk-utils": "0.8.1",
+        "@embeddable.com/sdk-core": "4.0.2",
+        "@embeddable.com/sdk-utils": "0.8.2",
         "@happy-dom/global-registrator": "^15.11.0",
         "@vitejs/plugin-react": "^4.3.2",
         "astring": "^1.8.6",
@@ -1073,9 +1073,9 @@
       }
     },
     "node_modules/@embeddable.com/sdk-utils": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-utils/-/sdk-utils-0.8.1.tgz",
-      "integrity": "sha512-4hZYZgFxNi038X2mtaDJVMwHEw/8RWw8zPE8tU20xWjhEqgIAwPipqTIss64bvaMwnfKtL1vwZ1kZijCprGgFA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-utils/-/sdk-utils-0.8.2.tgz",
+      "integrity": "sha512-b+Ufora6+n6e9tzeFYVdK5hmscCJTRFBeup0+mjfi/+LS1F5rIuGIXvNV9peW195WrgJUCHB3Qgwi5Tb8lj+vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
     }
   },
   "devDependencies": {
-    "@embeddable.com/core": "^2.10.5",
-    "@embeddable.com/react": "^2.10.6",
-    "@embeddable.com/sdk-core": "^4.0.0",
-    "@embeddable.com/sdk-react": "^4.0.0",
+    "@embeddable.com/core": "^2.10.7",
+    "@embeddable.com/react": "^2.10.8",
+    "@embeddable.com/sdk-core": "^4.0.2",
+    "@embeddable.com/sdk-react": "^4.0.2",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/d3-scale": "^4.0.8",
     "@types/leaflet": "^1.9.14",

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -61,7 +61,6 @@ type Props = {
   xAxis: Dimension;
   xAxisTitle?: string;
   yAxisTitle?: string;
-  granularity?: Granularity;
   showSecondYAxis?: boolean;
   secondAxisTitle?: string;
 };
@@ -78,9 +77,10 @@ export default function BarChart({ ...props }: Props) {
 }
 
 function chartData(props: Props): ChartData<'bar' | 'line'> {
-  const { results, xAxis, metrics, granularity, lineMetrics, showSecondYAxis } = props;
+  const { results, xAxis, metrics, lineMetrics, showSecondYAxis } = props;
+  const granularity = xAxis?.inputs?.granularity as Granularity | undefined;
 
-  let dateFormat: string | undefined;
+  let dateFormat: string = 'yyyy-mm-dd';
   if (xAxis.nativeType === 'time' && granularity) {
     dateFormat = DATE_DISPLAY_FORMATS[granularity];
   }
@@ -97,34 +97,36 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
     ),
   ] as string[];
 
-  const metricsDatasets =  metrics?.map((metric, i) => ({
-    barPercentage: 0.8,
-    barThickness: 'flex',
-    maxBarThickness: 50,
-    minBarLength: 0,
-    borderRadius: 4,
-    label: metric.title,
-    data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
-    backgroundColor: COLORS[i % COLORS.length],
-    order: 1
-  })) || [];
-
-  //optional metrics to display as a line on the barchart 
-  const lineMetricsDatasets = lineMetrics?.map((metric, i) => ({
+  const metricsDatasets =
+    metrics?.map((metric, i) => ({
+      barPercentage: 0.8,
+      barThickness: 'flex',
+      maxBarThickness: 50,
+      minBarLength: 0,
+      borderRadius: 4,
       label: metric.title,
       data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
-      backgroundColor: COLORS[metrics.length + i % COLORS.length],
-      borderColor: COLORS[metrics.length + i % COLORS.length],
+      backgroundColor: COLORS[i % COLORS.length],
+      order: 1,
+    })) || [];
+
+  //optional metrics to display as a line on the barchart
+  const lineMetricsDatasets =
+    lineMetrics?.map((metric, i) => ({
+      label: metric.title,
+      data: results?.data?.map((d) => parseFloat(d[metric.name] || 0)) || [],
+      backgroundColor: COLORS[metrics.length + (i % COLORS.length)],
+      borderColor: COLORS[metrics.length + (i % COLORS.length)],
       cubicInterpolationMode: 'monotone' as const,
       pointRadius: 2,
       pointHoverRadius: 3,
       type: 'line' as const,
       order: 0,
       yAxisID: showSecondYAxis ? 'y1' : 'y',
-  })) || [];
+    })) || [];
 
   return {
     labels,
-    datasets: [...metricsDatasets, ...lineMetricsDatasets]
+    datasets: [...metricsDatasets, ...lineMetricsDatasets],
   };
 }

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -78,7 +78,7 @@ export default function BarChart({ ...props }: Props) {
 
 function chartData(props: Props): ChartData<'bar' | 'line'> {
   const { results, xAxis, metrics, lineMetrics, showSecondYAxis } = props;
-  const granularity = xAxis?.inputs?.granularity as Granularity | undefined;
+  const granularity = xAxis?.inputs?.granularity;
 
   let dateFormat: string = 'yyyy-mm-dd';
   if (xAxis.nativeType === 'time' && granularity) {


### PR DESCRIPTION
- Bar chart respects granularity sub input
- Bar chart has a default date format if granularity isn't set, instead of displaying the entire UTC string

Note: this is identical to [the V1 PR](https://github.com/embeddable-hq/vanilla-components-v1/pull/98) it's just that prettier reformatted a bunch of stuff.