### PR TITLE
TPS-848 - Tables don't display boolean values

### DIFF
--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -180,9 +180,14 @@ export default (props: Props) => {
   );
 };
 
-function formatColumn(text: string | number, column: DimensionOrMeasure) {
+function formatColumn(text: string | number | boolean, column: DimensionOrMeasure) {
   if (typeof text === 'number' || column.nativeType === 'number') {
     return formatValue(`${text}`, { type: 'number', meta: column?.meta });
+  }
+
+  if (typeof text === 'boolean') {
+    // don't use formatValue for booleans, just return the string representation
+    return text ? 'True' : 'False';
   }
 
   if (text && column.nativeType === 'time') return formatValue(text, 'date');

--- a/src/models/cubes/orders.cube.yml
+++ b/src/models/cubes/orders.cube.yml
@@ -29,6 +29,12 @@ cubes:
         rolling_window:
           trailing: unbounded
 
+      - name: is_large_order
+        type: boolean
+        sql: CASE WHEN COUNT(*) > 10 THEN TRUE ELSE FALSE END
+        title: 'Is Large Order'
+        description: 'Returns true if the order count is greater than 10'
+
     joins:
       - name: products # the name of the data model to join to (not the table)
         sql: '{CUBE}.product_id = {products}.id'


### PR DESCRIPTION
**Description**
This fixes an issue where boolean values coming in from models were being displayed as empty spaces in both the standard and pivot tables. We now return the string value of the boolean in all cases.

Also adds an example boolean to the Orders model in case we need to do future testing

**Acceptance Criteria**
- [x] Tables display `True` or `False` appropriately with boolean data
- [x] Tables behave as normal with other data