### PR TITLE
EM-2144: Enable automatic granularity support in all components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ license-report.csv
 
 # misc
 csvjson.json
+
+# Cursor IDE
+.cursor

--- a/embeddable.config.js
+++ b/embeddable.config.js
@@ -4,11 +4,11 @@ import react from '@embeddable.com/sdk-react';
 export default defineConfig({
   plugins: [react],
 
-  // 
+  //
   // Uncomment for US deployments
   //
   // region: 'US'
-  
+
   //
   // Uncomment for EU deployments
   //

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       },
       "devDependencies": {
         "@embeddable.com/core": "^2.10.7",
-        "@embeddable.com/react": "^2.10.8",
+        "@embeddable.com/react": "^2.10.9",
         "@embeddable.com/sdk-core": "^4.0.2",
         "@embeddable.com/sdk-react": "^4.0.2",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/@embeddable.com/react": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.10.8.tgz",
-      "integrity": "sha512-pECZCWOiOX6iHOyXr+3y1y06XXZBf8Sup7c2Z57b9X7bQiOj+Xr0M3OTpzSo1FHnqCJ+IUIJd2Pdr7cf966C4w==",
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.10.9.tgz",
+      "integrity": "sha512-w2KkUcS2JLX91jbZ7D9Y/BFsODoCZ0quUVfAorh0zAbLwquXJdTRdIYZzMT4Jj2aJnD2zJ9iEvbs3ZhZ2qjodg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@embeddable.com/core": "^2.10.7",
-    "@embeddable.com/react": "^2.10.8",
+    "@embeddable.com/react": "^2.10.9",
     "@embeddable.com/sdk-core": "^4.0.2",
     "@embeddable.com/sdk-react": "^4.0.2",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/src/components/vanilla/charts/BarChart/BarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/BarChart.emb.ts
@@ -197,7 +197,7 @@ export default defineComponent(Component, meta, {
       reverseXAxis: inputs.reverseXAxis,
       results: loadData({
         from: inputs.ds,
-        select: [...dimensions, ...measures],
+        select: [dimensions, measures],
         orderBy: orderProp,
         limit: inputs.limit || 50,
       }),

--- a/src/components/vanilla/charts/BarChart/BarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/BarChart.emb.ts
@@ -197,8 +197,7 @@ export default defineComponent(Component, meta, {
       reverseXAxis: inputs.reverseXAxis,
       results: loadData({
         from: inputs.ds,
-        dimensions,
-        measures,
+        select: [...dimensions, ...measures],
         orderBy: orderProp,
         limit: inputs.limit || 50,
       }),

--- a/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
@@ -24,6 +24,7 @@ export const meta = {
       config: {
         dataset: 'ds',
         supportedTypes: ['time'],
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -162,13 +163,14 @@ export default defineComponent(Component, meta, {
       results: loadData({
         from: inputs.ds,
         limit: inputs.limit || 500,
-        timeDimensions: [
+        select: [
           {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          ...(inputs.metrics || []),
+          ...(inputs.lineMetrics || []),
         ],
-        measures: [...(inputs.metrics || []), ...(inputs.lineMetrics || [])],
         orderBy: [
           {
             property: inputs.xAxis,

--- a/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/TimeSeriesBarChart.emb.ts
@@ -168,8 +168,8 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
-          ...(inputs.metrics || []),
-          ...(inputs.lineMetrics || []),
+          inputs.metrics,
+          inputs.lineMetrics,
         ],
         orderBy: [
           {

--- a/src/components/vanilla/charts/BubbleChart/BubbleChart.emb.ts
+++ b/src/components/vanilla/charts/BubbleChart/BubbleChart.emb.ts
@@ -23,6 +23,7 @@ export const meta = {
       label: 'X-Axis',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -152,19 +153,19 @@ export default defineComponent(Component, meta, {
         ? loadData({
             from: inputs.ds,
             orderBy: orderProp,
-            timeDimensions: [
+            select: [
               {
                 dimension: inputs.xAxis?.name,
                 granularity: inputs.granularity,
               },
+              inputs.yAxis,
+              inputs.bubbleSize,
             ],
-            measures: [inputs.yAxis, inputs.bubbleSize],
             limit: inputs.limit || 50,
           })
         : loadData({
             from: inputs.ds,
-            dimensions: [inputs.xAxis],
-            measures: [inputs.yAxis, inputs.bubbleSize],
+            select: [inputs.xAxis, inputs.yAxis, inputs.bubbleSize],
             limit: inputs.limit || 50,
           }),
     };

--- a/src/components/vanilla/charts/BubbleMapChart/BubbleMapChart.emb.ts
+++ b/src/components/vanilla/charts/BubbleMapChart/BubbleMapChart.emb.ts
@@ -130,8 +130,7 @@ export default defineComponent(Component, meta, {
       results: loadData({
         from: inputs.ds,
         limit: 5000,
-        dimensions: [inputs.bubblePlacement],
-        measures: [inputs.metric],
+        select: [inputs.bubblePlacement, inputs.metric],
       }),
     };
   },

--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -174,15 +174,13 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
-          ...(inputs.comparisonXAxis
-            ? [
-                {
-                  dimension: inputs.comparisonXAxis.name,
-                  granularity: inputs.granularity,
-                },
-              ]
-            : []),
-          ...inputs.metrics,
+          inputs.comparisonXAxis
+            ? {
+                dimension: inputs.comparisonXAxis.name,
+                granularity: inputs.granularity,
+              }
+            : null,
+          inputs.metrics,
         ],
         filters:
           inputs.timeFilter && inputs.xAxis
@@ -202,7 +200,7 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
-          ...inputs.metrics,
+          inputs.metrics,
         ],
         limit: !inputs.prevTimeFilter ? 1 : 500,
         orderBy: orderProp,

--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -174,12 +174,12 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
-          inputs.comparisonXAxis
-            ? {
+          ...(inputs.comparisonXAxis
+            ? [{
                 dimension: inputs.comparisonXAxis.name,
                 granularity: inputs.granularity,
-              }
-            : null,
+              }]
+            : []),
           inputs.metrics,
         ],
         filters:

--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -24,6 +24,7 @@ export const meta = {
       config: {
         dataset: 'ds',
         supportedTypes: ['time'],
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -34,6 +35,7 @@ export const meta = {
       config: {
         dataset: 'ds',
         supportedTypes: ['time'],
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -167,7 +169,7 @@ export default defineComponent(Component, meta, {
         from: inputs.ds,
         limit: 500,
         orderBy: orderProp,
-        timeDimensions: [
+        select: [
           {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
@@ -180,8 +182,8 @@ export default defineComponent(Component, meta, {
                 },
               ]
             : []),
+          ...inputs.metrics,
         ],
-        measures: inputs.metrics,
         filters:
           inputs.timeFilter && inputs.xAxis
             ? [
@@ -195,15 +197,15 @@ export default defineComponent(Component, meta, {
       }),
       prevResults: loadData({
         from: inputs.ds,
-        timeDimensions: [
+        select: [
           {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          ...inputs.metrics,
         ],
         limit: !inputs.prevTimeFilter ? 1 : 500,
         orderBy: orderProp,
-        measures: inputs.metrics,
         filters:
           inputs.prevTimeFilter && inputs.xAxis
             ? [

--- a/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
+++ b/src/components/vanilla/charts/DownloadButton/DownloadButton.emb.ts
@@ -67,8 +67,7 @@ export default defineComponent<Props, typeof meta, { downloading: boolean }>(Com
     if (downloading) {
       results = loadData({
         from: inputs.ds,
-        dimensions: inputs.columns.filter((c) => isDimension(c)).map((c) => c as Dimension),
-        measures: inputs.columns.filter((c) => isMeasure(c)).map((c) => c as Measure),
+        select: inputs.columns,
         limit: inputs.maxRows || undefined,
       });
       return {

--- a/src/components/vanilla/charts/DynamicAxisBar/DynamicAxisBar.emb.ts
+++ b/src/components/vanilla/charts/DynamicAxisBar/DynamicAxisBar.emb.ts
@@ -147,7 +147,7 @@ export default defineComponent<Props, typeof meta, EmbeddableState>(Component, m
                 dimension: selectedDimension.name,
                 granularity: inputs.granularity,
               },
-              ...inputs.metrics,
+              inputs.metrics,
             ],
             orderBy: [
               {
@@ -159,7 +159,7 @@ export default defineComponent<Props, typeof meta, EmbeddableState>(Component, m
           })
         : loadData({
             from: inputs.ds,
-            select: [selectedDimension, ...inputs.metrics],
+            select: [selectedDimension, inputs.metrics],
             orderBy: [
               {
                 property: inputs.metrics[0],

--- a/src/components/vanilla/charts/DynamicAxisBar/DynamicAxisBar.emb.ts
+++ b/src/components/vanilla/charts/DynamicAxisBar/DynamicAxisBar.emb.ts
@@ -21,6 +21,7 @@ export const meta = {
       label: 'Default X-axis',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -31,6 +32,7 @@ export const meta = {
       label: 'X-axis options',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -140,13 +142,13 @@ export default defineComponent<Props, typeof meta, EmbeddableState>(Component, m
       results: isTimeDimension
         ? loadData({
             from: inputs.ds,
-            timeDimensions: [
+            select: [
               {
                 dimension: selectedDimension.name,
                 granularity: inputs.granularity,
               },
+              ...inputs.metrics,
             ],
-            measures: inputs.metrics,
             orderBy: [
               {
                 property: selectedDimension,
@@ -157,8 +159,7 @@ export default defineComponent<Props, typeof meta, EmbeddableState>(Component, m
           })
         : loadData({
             from: inputs.ds,
-            dimensions: [selectedDimension],
-            measures: inputs.metrics,
+            select: [selectedDimension, ...inputs.metrics],
             orderBy: [
               {
                 property: inputs.metrics[0],

--- a/src/components/vanilla/charts/KPIChart/KPIChart.emb.ts
+++ b/src/components/vanilla/charts/KPIChart/KPIChart.emb.ts
@@ -124,7 +124,7 @@ export default defineComponent(Component, meta, {
       ...inputs,
       results: loadData({
         from: inputs.ds,
-        measures: [inputs.metric],
+        select: [inputs.metric],
         filters:
           inputs.timeFilter?.from && inputs.timeProperty
             ? [
@@ -140,7 +140,7 @@ export default defineComponent(Component, meta, {
         inputs.timeProperty &&
         loadData({
           from: inputs.ds,
-          measures: [inputs.metric],
+          select: [inputs.metric],
           limit: !inputs.prevTimeFilter?.from ? 1 : undefined,
           filters: inputs.prevTimeFilter?.from
             ? [

--- a/src/components/vanilla/charts/KPIChart/KPIChartText.emb.ts
+++ b/src/components/vanilla/charts/KPIChart/KPIChartText.emb.ts
@@ -106,8 +106,7 @@ export default defineComponent(Component, meta, {
       ...inputs,
       results: loadData({
         from: inputs.ds,
-        measures: [inputs.metric],
-        dimensions: [inputs.dimension],
+        select: [inputs.metric, inputs.dimension],
         orderBy: [
           {
             property: inputs.metric,

--- a/src/components/vanilla/charts/KPIChart/SimpleKPIChart.emb.ts
+++ b/src/components/vanilla/charts/KPIChart/SimpleKPIChart.emb.ts
@@ -92,7 +92,7 @@ export default defineComponent(Component, meta, {
       ...inputs,
       results: loadData({
         from: inputs.ds,
-        measures: [inputs.metric],
+        select: [inputs.metric],
       }),
     };
   },

--- a/src/components/vanilla/charts/LineChart/LineChart.emb.ts
+++ b/src/components/vanilla/charts/LineChart/LineChart.emb.ts
@@ -148,7 +148,7 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
-          ...inputs.metrics,
+          inputs.metrics,
         ],
       }),
     };

--- a/src/components/vanilla/charts/LineChart/LineChart.emb.ts
+++ b/src/components/vanilla/charts/LineChart/LineChart.emb.ts
@@ -24,6 +24,7 @@ export const meta = {
       config: {
         dataset: 'ds',
         supportedTypes: ['time'],
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -142,13 +143,13 @@ export default defineComponent(Component, meta, {
         from: inputs.ds,
         limit: inputs.limit || 500,
         orderBy: orderProp,
-        timeDimensions: [
+        select: [
           {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          ...inputs.metrics,
         ],
-        measures: inputs.metrics,
       }),
     };
   },

--- a/src/components/vanilla/charts/MapChart/MapChart.emb.ts
+++ b/src/components/vanilla/charts/MapChart/MapChart.emb.ts
@@ -74,8 +74,7 @@ export default defineComponent(Component, meta, {
       ...inputs,
       results: loadData({
         from: inputs.ds,
-        dimensions: [inputs.segments],
-        measures: [inputs.metric],
+        select: [inputs.segments, inputs.metric],
       }),
     };
   },

--- a/src/components/vanilla/charts/PieChart/PieChart.emb.ts
+++ b/src/components/vanilla/charts/PieChart/PieChart.emb.ts
@@ -118,10 +118,10 @@ export default defineComponent(Component, meta, {
   props: (inputs: Inputs<typeof meta>) => {
     return {
       ...inputs,
+      granularity: inputs.slice?.inputs?.granularity,
       results: loadData({
         from: inputs.ds,
-        dimensions: [inputs.slice],
-        measures: [inputs.metric],
+        select: [inputs.slice, inputs.metric],
       }),
     };
   },

--- a/src/components/vanilla/charts/PivotTable/PivotTable.emb.ts
+++ b/src/components/vanilla/charts/PivotTable/PivotTable.emb.ts
@@ -45,6 +45,7 @@ export const meta = {
       array: true,
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -55,6 +56,7 @@ export const meta = {
       array: true,
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -194,16 +196,18 @@ export default defineComponent(Component, meta, {
               ...resultSet,
               [`resultsDimension${index}`]: loadData({
                 from: inputs.ds,
-                dimensions: dimensionsToFetch.filter(
-                  (dimension) => dimension.nativeType !== 'time',
-                ),
-                measures: measures,
-                timeDimensions: dimensionsToFetch
-                  .filter((dimension) => dimension.nativeType === 'time')
-                  .map((timeDimension) => ({
-                    dimension: timeDimension.name,
-                    granularity: inputs.granularity,
-                  })),
+                select: [
+                  ...dimensionsToFetch.filter(
+                    (dimension) => dimension.nativeType !== 'time',
+                  ),
+                  ...dimensionsToFetch
+                    .filter((dimension) => dimension.nativeType === 'time')
+                    .map((timeDimension) => ({
+                      dimension: timeDimension.name,
+                      granularity: inputs.granularity,
+                    })),
+                  ...measures,
+                ],
                 orderBy: sort.slice(0, index + 1),
                 limit: 10_000,
               }),
@@ -212,16 +216,18 @@ export default defineComponent(Component, meta, {
         : {
             resultsDimension0: loadData({
               from: inputs.ds,
-              dimensions: [...(filteredRowDimensions || []), ...columnDimensions].filter(
-                (dimension) => dimension.nativeType !== 'time',
-              ),
-              timeDimensions: [...(filteredRowDimensions || []), ...columnDimensions]
-                .filter((dimension) => dimension.nativeType === 'time')
-                .map((timeDimension) => ({
-                  dimension: timeDimension.name,
-                  granularity: inputs.granularity,
-                })),
-              measures: measures,
+              select: [
+                ...[...(filteredRowDimensions || []), ...columnDimensions].filter(
+                  (dimension) => dimension.nativeType !== 'time',
+                ),
+                ...[...(filteredRowDimensions || []), ...columnDimensions]
+                  .filter((dimension) => dimension.nativeType === 'time')
+                  .map((timeDimension) => ({
+                    dimension: timeDimension.name,
+                    granularity: inputs.granularity,
+                  })),
+                ...measures,
+              ],
               limit: 10_000,
             }),
           };

--- a/src/components/vanilla/charts/PivotTable/PivotTable.emb.ts
+++ b/src/components/vanilla/charts/PivotTable/PivotTable.emb.ts
@@ -197,16 +197,16 @@ export default defineComponent(Component, meta, {
               [`resultsDimension${index}`]: loadData({
                 from: inputs.ds,
                 select: [
-                  ...dimensionsToFetch.filter(
+                  dimensionsToFetch.filter(
                     (dimension) => dimension.nativeType !== 'time',
                   ),
-                  ...dimensionsToFetch
+                  dimensionsToFetch
                     .filter((dimension) => dimension.nativeType === 'time')
                     .map((timeDimension) => ({
                       dimension: timeDimension.name,
                       granularity: inputs.granularity,
                     })),
-                  ...measures,
+                  measures,
                 ],
                 orderBy: sort.slice(0, index + 1),
                 limit: 10_000,
@@ -217,16 +217,16 @@ export default defineComponent(Component, meta, {
             resultsDimension0: loadData({
               from: inputs.ds,
               select: [
-                ...[...(filteredRowDimensions || []), ...columnDimensions].filter(
+                [...(filteredRowDimensions || []), ...columnDimensions].filter(
                   (dimension) => dimension.nativeType !== 'time',
                 ),
-                ...[...(filteredRowDimensions || []), ...columnDimensions]
+                [...(filteredRowDimensions || []), ...columnDimensions]
                   .filter((dimension) => dimension.nativeType === 'time')
                   .map((timeDimension) => ({
                     dimension: timeDimension.name,
                     granularity: inputs.granularity,
                   })),
-                ...measures,
+                measures,
               ],
               limit: 10_000,
             }),

--- a/src/components/vanilla/charts/ScatterChart/ScatterChart.emb.ts
+++ b/src/components/vanilla/charts/ScatterChart/ScatterChart.emb.ts
@@ -151,13 +151,13 @@ export default defineComponent(Component, meta, {
                 dimension: inputs.xAxis?.name,
                 granularity: inputs.granularity,
               },
-              ...inputs.metrics,
+              inputs.metrics,
             ],
             limit: inputs.limit || 50,
           })
         : loadData({
             from: inputs.ds,
-            select: [inputs.xAxis, ...inputs.metrics],
+            select: [inputs.xAxis, inputs.metrics],
             limit: inputs.limit || 50,
           }),
     };

--- a/src/components/vanilla/charts/ScatterChart/ScatterChart.emb.ts
+++ b/src/components/vanilla/charts/ScatterChart/ScatterChart.emb.ts
@@ -23,6 +23,7 @@ export const meta = {
       label: 'X-Axis',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -33,6 +34,7 @@ export const meta = {
       array: true,
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -144,19 +146,18 @@ export default defineComponent(Component, meta, {
         ? loadData({
             from: inputs.ds,
             orderBy: orderProp,
-            timeDimensions: [
+            select: [
               {
                 dimension: inputs.xAxis?.name,
                 granularity: inputs.granularity,
               },
+              ...inputs.metrics,
             ],
-            measures: inputs.metrics,
             limit: inputs.limit || 50,
           })
         : loadData({
             from: inputs.ds,
-            dimensions: [inputs.xAxis],
-            measures: inputs.metrics,
+            select: [inputs.xAxis, ...inputs.metrics],
             limit: inputs.limit || 50,
           }),
     };

--- a/src/components/vanilla/charts/StackedAreaChart/MultiDimensionLineChart.emb.ts
+++ b/src/components/vanilla/charts/StackedAreaChart/MultiDimensionLineChart.emb.ts
@@ -22,6 +22,7 @@ export const meta = {
       config: {
         dataset: 'ds',
         supportedTypes: ['time'],
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -31,6 +32,7 @@ export const meta = {
       label: 'Grouping',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -40,6 +42,7 @@ export const meta = {
       label: 'Metric',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -137,14 +140,14 @@ export default defineComponent(Component, meta, {
         from: inputs.ds,
         limit: inputs.limit || 500,
         orderBy: orderProp,
-        timeDimensions: [
+        select: [
           {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          inputs.segment,
+          inputs.metric,
         ],
-        dimensions: [inputs.segment],
-        measures: [inputs.metric],
       }),
     };
   },

--- a/src/components/vanilla/charts/StackedAreaChart/StackedAreaChart.emb.ts
+++ b/src/components/vanilla/charts/StackedAreaChart/StackedAreaChart.emb.ts
@@ -22,6 +22,7 @@ export const meta = {
       config: {
         dataset: 'ds',
         supportedTypes: ['time'],
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -31,6 +32,7 @@ export const meta = {
       label: 'Segment',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -40,6 +42,7 @@ export const meta = {
       label: 'Metric',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -143,14 +146,14 @@ export default defineComponent(Component, meta, {
         from: inputs.ds,
         limit: inputs.limit || 500,
         orderBy: orderProp,
-        timeDimensions: [
+        select: [
           {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          inputs.segment,
+          inputs.metric,
         ],
-        dimensions: [inputs.segment],
-        measures: [inputs.metric],
       }),
     };
   },

--- a/src/components/vanilla/charts/StackedBarChart/StackedBarChart.emb.ts
+++ b/src/components/vanilla/charts/StackedBarChart/StackedBarChart.emb.ts
@@ -160,8 +160,7 @@ export default defineComponent(Component, meta, {
       isGroupedBar: true,
       results: loadData({
         from: inputs.ds,
-        dimensions: [inputs.xAxis, inputs.segment],
-        measures: [inputs.metric],
+        select: [inputs.xAxis, inputs.segment, inputs.metric],
         orderBy: orderProp,
       }),
     };

--- a/src/components/vanilla/charts/StackedBarChart/TimeSeriesStackedBarChart.emb.ts
+++ b/src/components/vanilla/charts/StackedBarChart/TimeSeriesStackedBarChart.emb.ts
@@ -22,6 +22,7 @@ export const meta = {
       config: {
         dataset: 'ds',
         supportedTypes: ['time'],
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -38,6 +39,7 @@ export const meta = {
       label: 'Grouping',
       config: {
         dataset: 'ds',
+        hideGranularity: true,
       },
       category: 'Chart data',
     },
@@ -146,14 +148,14 @@ export default defineComponent(Component, meta, {
       useCustomDateFormat: true,
       results: loadData({
         from: inputs.ds,
-        timeDimensions: [
+        select: [
           {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          inputs.segment,
+          inputs.metric,
         ],
-        dimensions: [inputs.segment],
-        measures: [inputs.metric],
         orderBy: [
           {
             property: inputs.xAxis,

--- a/src/components/vanilla/charts/TableChart/TableChart.emb.ts
+++ b/src/components/vanilla/charts/TableChart/TableChart.emb.ts
@@ -163,8 +163,7 @@ export default defineComponent<
         ? { isLoading: true }
         : loadData({
             from: inputs.ds,
-            dimensions: (inputs.columns?.filter((c) => isDimension(c)) as Dimension[]) || [],
-            measures: (inputs.columns?.filter((c) => isMeasure(c)) as Measure[]) || [],
+            select: inputs.columns || [],
             limit,
             offset: limit * (state?.page || 0),
             orderBy: state?.sort || defaultSort,
@@ -172,9 +171,8 @@ export default defineComponent<
 
     // All results get loaded when the download all button is clicked (otherwise they return empty)
     const allResults = loadData({
-      from: inputs.ds,
-      dimensions: (inputs.columns?.filter((c) => isDimension(c)) as Dimension[]) || [],
-      measures: (inputs.columns?.filter((c) => isMeasure(c)) as Measure[]) || [],
+            from: inputs.ds,
+            select: inputs.columns || [],
       limit: state?.downloadAll ? 10_000 : 0,
       offset: 0,
       orderBy: state?.sort || defaultSort,

--- a/src/components/vanilla/controls/Dropdown/Dropdown.emb.ts
+++ b/src/components/vanilla/controls/Dropdown/Dropdown.emb.ts
@@ -88,7 +88,7 @@ export default defineComponent<Props, typeof meta, { search: string }>(Component
       ...inputs,
       options: loadData({
         from: inputs.ds,
-        dimensions: inputs.property ? [inputs.property] : [],
+        select: inputs.property ? [inputs.property] : [],
         limit: inputs.limit || 1000,
         filters:
           embState?.search && inputs.property

--- a/src/components/vanilla/controls/MultiSelectDropdown/MultiSelectDropdown.emb.ts
+++ b/src/components/vanilla/controls/MultiSelectDropdown/MultiSelectDropdown.emb.ts
@@ -92,7 +92,7 @@ export default defineComponent<Props, typeof meta, { search: string }>(Component
       ...inputs,
       options: loadData({
         from: inputs.ds,
-        dimensions: inputs.property ? [inputs.property] : [],
+        select: inputs.property ? [inputs.property] : [],
         limit: inputs.limit || 1000,
         filters:
           embState?.search && inputs.property


### PR DESCRIPTION
## Summary
This PR introduces automatic granularity support to all components in the vanilla-components repository, aligning with the recent migration to the unified select array API structure.

## Key Changes

### 1. Migration to Select API
- Updated all `loadData` calls across 24 components to use the new `select` array instead of separate `dimensions`, `measures`, and `timeDimensions` parameters
- This change enables components to handle TimeDimension objects with granularity specifications

### 2. Granularity Control Management
Added `hideGranularity: true` to components that already have their own granularity controls to prevent duplicate pickers:
- Time series charts (TimeSeriesBarChart, LineChart, CompareLineChart, etc.)
- Components with time-based dimensions (DynamicAxisBar, BubbleChart, ScatterChart)
- Multi-dimensional charts (StackedAreaChart, MultiDimensionLineChart, PivotTable)

### 3. Component-Specific Updates
- **PieChart**: Added granularity extraction from slice dimension inputs
- **Time Series Components**: Maintained legacy granularity approach while preventing automatic pickers
- **Control Components**: Updated Dropdown and MultiSelectDropdown to use select API

## Components Updated
**Charts**: BarChart, TimeSeriesBarChart, DynamicAxisBar, CompareLineChart, LineChart, StackedAreaChart, MultiDimensionLineChart, BubbleChart, ScatterChart, StackedBarChart, TimeSeriesStackedBarChart, PieChart, MapChart, BubbleMapChart, KPIChart, SimpleKPIChart, KPIChartText, TableChart, DownloadButton, PivotTable

**Controls**: Dropdown, MultiSelectDropdown



## Related
- Parent Epic: EM-2105
- Similar implementation: [PR #103 in vanilla-components-v1](https://github.com/embeddable-hq/vanilla-components-v1/pull/103)


https://github.com/user-attachments/assets/7e04b6db-fcd3-4bc8-8a39-767edf90961d

