### PR TITLE
update readme to indicate repo is in maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,47 @@
+# This Repo Is In Maintenance Mode
+
+Unless you are an existing client who has cloned this repo in the past, please do not clone or otherwise use this repo! This is the v0 version of Vanilla Components. The current v1 version of [Vanilla Components](https://github.com/embeddable-hq/vanilla-components-v1), which allows the importing of the components as a package and is what we recommend for all of our newer clients, lives in its own repo.
+
+The "clone the repo" version of Vanilla Components (this repo) will only receive updates in the future if there are significant bug fixes, or if the components need to be updated to work with changes in the Embeddable SDK or Platform.
+
+## Helpful Links
+
+- [Vanilla Components v1 Repo](https://github.com/embeddable-hq/vanilla-components-v1)
+- [Intro to Vanilla Components v1 for Existing Users](https://docs.embeddable.com/development/theme-welcome)
+- [Full Instructions for Upgrading from v0 to v1](https://docs.embeddable.com/development/theme-upgrading)
+
+---
+
+Legacy README:
+
 # Embeddable.com Starter Pack
 
 Hello and welcome to our Embeddable components **starter pack** built just for you by the Embeddable team ❤️ We wish to thank you for using our platform and welcome any feedback.
 
 ![example-dash](https://github.com/embeddable-hq/vanilla-components/assets/6795003/3f38f938-7848-4e25-8cc0-90160398f0a1)
 
-
 ### Installation
 
 `npm i` # requires node 20 or later
 
 ### Build & Deploy
+
 This is how you push code changes to your Embeddable workspace
 
- 1. Head to https://app.us.embeddable.com (or https://app.eu.embeddable.com) and grab your **API Key**.
+1.  Head to https://app.us.embeddable.com (or https://app.eu.embeddable.com) and grab your **API Key**.
 
- 2. **Set your location**: in [embeddable.config.ts](./embeddable.config.ts), uncomment either the US or EU config section.
+2.  **Set your location**: in [embeddable.config.ts](./embeddable.config.ts), uncomment either the US or EU config section.
 
- 3. **Build** the code bundle: `npm run embeddable:build`
+3.  **Build** the code bundle: `npm run embeddable:build`
 
- 4. **Push** the above code bundle to your workspace:
- 
-   `npm run embeddable:push -- --api-key <API Key> --email <Email> --message <Message>`
+4.  **Push** the above code bundle to your workspace:
 
- 4. Head back to https://app.embeddable.com (or https://app.eu.embeddable.com) and "Create new Embeddable" using the **components** and **models** from your code bundle
+`npm run embeddable:push -- --api-key <API Key> --email <Email> --message <Message>`
+
+4.  Head back to https://app.embeddable.com (or https://app.eu.embeddable.com) and "Create new Embeddable" using the **components** and **models** from your code bundle
 
 ### Local Development
+
 This is a "Preview workspace" (local to you) that allows you make changes locally and see them instantly without needing to "Build and Deploy".
 
 `npm run embeddable:dev` (note: you may need to run `npm run embeddable:login` first)
@@ -40,6 +57,7 @@ You can then set up this repo as a [git remote](https://git-scm.com/book/en/v2/G
 Alternatively, if you'd prefer to integrate Embeddable's sdk directly into your existing codebase, take a look at [this repo](https://github.com/embeddable-hq/onboarding) for an example of a minimal setup.
 
 ### Debugging Data Models
+
 To test and debug your data models locally using Cube's data playground:
 
 Create a `.env` file in the same folder as `cube-playground.yml` and follow the instructions [here](https://cube.dev/docs/product/configuration/data-sources) to add your database's credentials.
@@ -58,7 +76,6 @@ In the playground you can:
 
 Official documentation on using Cube's playground can be found [here](https://cube.dev/docs/product/workspace/playground#running-playground).
 
-
 ### Debugging Pre-aggregations
 
 While cube playground is running, you can run `npm run cube:cubestore` to get access to a mysql interface on top of your locally stored preaggregations.
@@ -72,5 +89,5 @@ Official documentation on inspecting local pre-aggregations can be found [here](
 Environment variables can be set in a `.env` file in the root of the project. The following variables are available:
 
 | Variable name       | Type                     | Default Value | Description                  |
-|---------------------|--------------------------|---------------|------------------------------|
+| ------------------- | ------------------------ | ------------- | ---------------------------- |
 | CUBE_CLOUD_ENDPOINT | Cube Cloud Configuration |               | URL to connect to cube cloud |


### PR DESCRIPTION
We've moved v0 to maintenance mode but there's no indication of that in the Readme. This adds some text to that effect, and provides a bunch of helpful links for anyone who ends up here.