### PR TITLE
CS-120 - Table Next Button Not Working

### DIFF
--- a/src/components/vanilla/charts/TableChart/TableChart.emb.ts
+++ b/src/components/vanilla/charts/TableChart/TableChart.emb.ts
@@ -171,8 +171,8 @@ export default defineComponent<
 
     // All results get loaded when the download all button is clicked (otherwise they return empty)
     const allResults = loadData({
-            from: inputs.ds,
-            select: inputs.columns || [],
+      from: inputs.ds,
+      select: inputs.columns || [],
       limit: state?.downloadAll ? 10_000 : 0,
       offset: 0,
       orderBy: state?.sort || defaultSort,

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -34,6 +34,7 @@ export default (props: Props) => {
   const [maxRowsFit, setMaxRowFit] = useState(0);
   const [resizing, setResizing] = useState(false);
   const [isDownloadingAll, setIsDownloadingAll] = useState(false);
+  const [hasNextPage, setHasNextPage] = useState(false);
 
   const [meta, setMeta] = useEmbeddableState({
     downloadAll: false,
@@ -79,6 +80,12 @@ export default (props: Props) => {
     },
     [maxRowsFit, props.results],
   );
+
+  useEffect(() => {
+    if (props.results?.data?.length) {
+      setHasNextPage(props.limit ? props.results.data.length > props.limit - 1 : false);
+    }
+  }, [props.results, props.limit]);
 
   // We pass this to the download menu via the container
   const handleDownloadAll = useCallback(() => {
@@ -169,9 +176,7 @@ export default (props: Props) => {
 
       <Pagination
         currentPage={meta?.page || 0}
-        hasNextPage={
-          props.limit && results?.data?.length ? results?.data?.length < props.limit : false
-        }
+        hasNextPage={hasNextPage}
         onPageChange={(page) => {
           setMeta((meta) => ({ ...meta, page: page }));
         }}

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -83,7 +83,7 @@ export default (props: Props) => {
 
   useEffect(() => {
     if (props.results?.data?.length) {
-      setHasNextPage(props.limit ? props.results.data.length > props.limit - 1 : false);
+      setHasNextPage(props.limit ? props.results.data.length >= props.limit : false);
     }
   }, [props.results, props.limit]);
 


### PR DESCRIPTION
This restores pagination functionality that was impaired when we tried to fix the "Phantom next page" bug that can occur when the final page of a result set happens to exactly equal the length of the limit. Unfortunately there's not really a good way to deal with that bug that doesn't significantly impact pagination, so we're reintroducing it in favor of pagination working as expected for most people most of the time.

There is a [TPS ticket here](https://trevorio.atlassian.net/browse/TPS-878) and an [EM ticket here](https://trevorio.atlassian.net/browse/EM-2226) about improving loadData results, which would allow us to resolve the phantom next page issue (among other improvements). That's planned for next sprint (starting in three weeks).

Also I had to switch to a `useEffect` to reliably evaluate both values as they change during the data load.

Tested and works, including greying out the next page button on the final page of the chart ... EXCEPT if the final page's length happens to exactly equal the limit.