### PR TITLE
EM-000: Pin axios version to prevent supply chain attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
       "d3-interpolate": "^3.0.1",
       "d3-select": "^3.0.0",
       "d3-zoom": "^3.0.0"
-    }
+    },
+    "axios": "1.13.5"
   },
   "devDependencies": {
     "@embeddable.com/core": "^2.13.6",


### PR DESCRIPTION
## Summary
- Adds axios `1.13.5` to existing `overrides`, preventing automatic upgrade to compromised versions (`1.14.1` / `0.30.4`) from the [axios npm supply chain attack](https://github.com/theNetworkChuck/axios-attack-guide)
- axios is not a direct dependency in this repo but is pulled in transitively

## Test plan
- [ ] Verify `npm install` resolves axios to `1.13.5`
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)